### PR TITLE
Simplify and add tests for `COLLECTION_LOG_REGEX`

### DIFF
--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -67,7 +67,7 @@ public class DinkPlugin extends Plugin {
     public static final Pattern SLAYER_TASK_REGEX = Pattern.compile("You have completed your task! You killed (?<task>[\\d,]+ [^.]+)\\..*");
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
-    private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.]+)");
+    private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
     private static final Pattern PET_REGEX = Pattern.compile("You have a funny feeling like you.*");
 
     private String slayerTask = "";

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -66,7 +66,7 @@ public class DinkPlugin extends Plugin {
     public static final Pattern SLAYER_TASK_REGEX = Pattern.compile("You have completed your task! You killed (?<task>[\\d,]+ [^.]+)\\..*");
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
-    private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
+    public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
     private static final Pattern PET_REGEX = Pattern.compile("You have a funny feeling like you.*");
 
     private String slayerTask = "";

--- a/src/test/java/dink/test.kt
+++ b/src/test/java/dink/test.kt
@@ -54,10 +54,10 @@ class Matchers {
 
     @ParameterizedTest(name = "Collection log message should trigger {0}")
     @ArgumentsSource(CollectionLogProvider::class)
-    fun `Collection log regex finds match`(message: String, task: String) {
+    fun `Collection log regex finds match`(message: String, item: String) {
         val matcher = DinkPlugin.COLLECTION_LOG_REGEX.matcher(message)
         assertTrue(matcher.find())
-        assertEquals(task, matcher.group("collection"))
+        assertEquals(item, matcher.group("collection"))
     }
 
     @ParameterizedTest(name = "Collection log message should not trigger {0}")

--- a/src/test/java/dink/test.kt
+++ b/src/test/java/dink/test.kt
@@ -51,4 +51,36 @@ class Matchers {
             Arguments.of("You have completed your task! You killed 31 TzKal-Zuk. You gained 75 xp.", "31 TzKal-Zuk")
         )
     }
+
+    @ParameterizedTest(name = "Collection log message should trigger {0}")
+    @ArgumentsSource(CollectionLogProvider::class)
+    fun `Collection log regex finds match`(message: String, task: String) {
+        val matcher = DinkPlugin.COLLECTION_LOG_REGEX.matcher(message)
+        assertTrue(matcher.find())
+        assertEquals(task, matcher.group("collection"))
+    }
+
+    @ParameterizedTest(name = "Collection log message should not trigger {0}")
+    @ValueSource(
+        strings = [
+            "Forsen: forsen", // todo: add more bad examples
+        ]
+    )
+    fun `Collection log regex does not match`(message: String) {
+        val matcher = DinkPlugin.COLLECTION_LOG_REGEX.matcher(message)
+        assertFalse(matcher.find())
+    }
+
+    private class CollectionLogProvider : ArgumentsProvider {
+        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+            Arguments.of("New item added to your collection log: Red d'hide body (t)", "Red d'hide body (t)"),
+            Arguments.of("New item added to your collection log: Rune full helm (g)", "Rune full helm (g)"),
+            Arguments.of("New item added to your collection log: Robin hood hat", "Robin hood hat"),
+            Arguments.of("New item added to your collection log: Amulet of glory (t4)",
+                "Amulet of glory (t4)"),
+            Arguments.of("New item added to your collection log: Blue d'hide chaps (t)",
+                "Blue d'hide chaps (t)"),
+            Arguments.of("New item added to your collection log: Lumberjack Boots", "Lumberjack boots")
+        )
+    }
 }

--- a/src/test/java/dink/test.kt
+++ b/src/test/java/dink/test.kt
@@ -83,7 +83,7 @@ class Matchers {
                 "Amulet of glory (t4)"),
             Arguments.of("New item added to your collection log: Blue d'hide chaps (t)",
                 "Blue d'hide chaps (t)"),
-            Arguments.of("New item added to your collection log: Lumberjack Boots",
+            Arguments.of("New item added to your collection log: Lumberjack boots",
                 "Lumberjack boots")
         )
     }

--- a/src/test/java/dink/test.kt
+++ b/src/test/java/dink/test.kt
@@ -73,14 +73,18 @@ class Matchers {
 
     private class CollectionLogProvider : ArgumentsProvider {
         override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
-            Arguments.of("New item added to your collection log: Red d'hide body (t)", "Red d'hide body (t)"),
-            Arguments.of("New item added to your collection log: Rune full helm (g)", "Rune full helm (g)"),
-            Arguments.of("New item added to your collection log: Robin hood hat", "Robin hood hat"),
+            Arguments.of("New item added to your collection log: Red d'hide body (t)",
+                "Red d'hide body (t)"),
+            Arguments.of("New item added to your collection log: Rune full helm (g)",
+                "Rune full helm (g)"),
+            Arguments.of("New item added to your collection log: Robin hood hat",
+                "Robin hood hat"),
             Arguments.of("New item added to your collection log: Amulet of glory (t4)",
                 "Amulet of glory (t4)"),
             Arguments.of("New item added to your collection log: Blue d'hide chaps (t)",
                 "Blue d'hide chaps (t)"),
-            Arguments.of("New item added to your collection log: Lumberjack Boots", "Lumberjack boots")
+            Arguments.of("New item added to your collection log: Lumberjack Boots",
+                "Lumberjack boots")
         )
     }
 }

--- a/src/test/java/dink/test.kt
+++ b/src/test/java/dink/test.kt
@@ -57,7 +57,7 @@ class Matchers {
     fun `Collection log regex finds match`(message: String, item: String) {
         val matcher = DinkPlugin.COLLECTION_LOG_REGEX.matcher(message)
         assertTrue(matcher.find())
-        assertEquals(item, matcher.group("collection"))
+        assertEquals(item, matcher.group("itemName"))
     }
 
     @ParameterizedTest(name = "Collection log message should not trigger {0}")


### PR DESCRIPTION
While looking at #8 - I started thinking about gold and trimmed amour, as well as heraldic pieces, and I realized the existing regex does not match them.

While discussing adding `\(.+\)?` to the end of the regex, pajlada noted that we might as well just use `(.*)` and I agree with him.

https://regex101.com/r/OlqXHe/1

Fixes #3