### PR TITLE
Standardize settings order

### DIFF
--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -195,10 +195,21 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "lootSendImage",
+        name = "Send Image",
+        description = "Send image with the notification",
+        position = 12,
+        section = lootSection
+    )
+    default boolean lootSendImage() {
+        return true;
+    }
+
+    @ConfigItem(
         keyName = "lootIcons",
         name = "Show loot icons",
         description = "Show icons for the loot obtained",
-        position = 12,
+        position = 13,
         section = lootSection
     )
     default boolean lootIcons() {
@@ -209,7 +220,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "minLootValue",
         name = "Min Loot value",
         description = "Minimum value of the loot to notify",
-        position = 13,
+        position = 14,
         section = lootSection
     )
     default int minLootValue() {
@@ -220,22 +231,11 @@ public interface DinkPluginConfig extends Config {
         keyName = "lootNotifMessage",
         name = "Notification Message",
         description = "The message to be sent through the webhook. Use %USERNAME% to insert your username, %LOOT% to insert the loot and %SOURCE% to show the source of the loot",
-        position = 14,
+        position = 15,
         section = lootSection
     )
     default String lootNotifyMessage() {
         return "%USERNAME% has looted: \n\n%LOOT%\nFrom: %SOURCE%";
-    }
-
-    @ConfigItem(
-        keyName = "lootSendImage",
-        name = "Send Image",
-        description = "Send image with the notification",
-        position = 15,
-        section = lootSection
-    )
-    default boolean lootSendImage() {
-        return true;
     }
 
     @ConfigItem(

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -118,27 +118,26 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "petNotifMessage",
-        name = "Notification Message",
-        description = "The message to be sent through the webhook. Use %USERNAME% to insert your username",
-        position = 5,
-        section = petSection
-    )
-    default String petNotifyMessage() {
-        return "%USERNAME% has a funny feeling they are being followed";
-    }
-
-    @ConfigItem(
         keyName = "petSendImage",
         name = "Send Image",
         description = "Send image with the notification",
-        position = 6,
+        position = 5,
         section = petSection
     )
     default boolean petSendImage() {
         return true;
     }
 
+    @ConfigItem(
+        keyName = "petNotifMessage",
+        name = "Notification Message",
+        description = "The message to be sent through the webhook. Use %USERNAME% to insert your username",
+        position = 6,
+        section = petSection
+    )
+    default String petNotifyMessage() {
+        return "%USERNAME% has a funny feeling they are being followed";
+    }
 
     @ConfigItem(
         keyName = "levelEnabled",

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -85,25 +85,25 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "collectionNotifMessage",
-        name = "Notification Message",
-        description = "The message to be sent through the webhook. Use %USERNAME% to insert your username and %ITEM% for the item",
-        position = 2,
-        section = collectionSection
-    )
-    default String collectionNotifyMessage() {
-        return "%USERNAME% has added %ITEM% to their collection";
-    }
-
-    @ConfigItem(
         keyName = "collectionSendImage",
         name = "Send Image",
         description = "Send image with the notification",
-        position = 3,
+        position = 2,
         section = collectionSection
     )
     default boolean collectionSendImage() {
         return true;
+    }
+
+    @ConfigItem(
+        keyName = "collectionNotifMessage",
+        name = "Notification Message",
+        description = "The message to be sent through the webhook. Use %USERNAME% to insert your username and %ITEM% for the item",
+        position = 3,
+        section = collectionSection
+    )
+    default String collectionNotifyMessage() {
+        return "%USERNAME% has added %ITEM% to their collection";
     }
 
     @ConfigItem(

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -151,10 +151,21 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "levelSendImage",
+        name = "Send Image",
+        description = "Send image with the notification",
+        position = 8,
+        section = levelSection
+    )
+    default boolean levelSendImage() {
+        return true;
+    }
+
+    @ConfigItem(
         keyName = "levelInterval",
         name = "Notify Interval",
         description = "Interval between when a notification should be sent",
-        position = 8,
+        position = 9,
         section = levelSection
     )
     default int levelInterval() {
@@ -165,22 +176,11 @@ public interface DinkPluginConfig extends Config {
         keyName = "levelNotifMessage",
         name = "Notification Message",
         description = "The message to be sent through the webhook. Use %USERNAME% to insert your username and %SKILL% to insert the levelled skill(s)",
-        position = 9,
+        position = 10,
         section = levelSection
     )
     default String levelNotifyMessage() {
         return "%USERNAME% has levelled %SKILL%";
-    }
-
-    @ConfigItem(
-        keyName = "levelSendImage",
-        name = "Send Image",
-        description = "Send image with the notification",
-        position = 10,
-        section = levelSection
-    )
-    default boolean levelSendImage() {
-        return true;
     }
 
     @ConfigItem(


### PR DESCRIPTION
As you might have noticed, but not really cared, each group of notifications has a differing setting order.
`(the first 4 have one standard and the last 3 have another)`

I went ahead and standardized it to the following `(I picked the one the last 3 used)`:
1. Enable
2. Send Image
2a/b. notification_specific_settings 
3. Notification Message

before: (rectangle = bad | circle = good)
![dinkplugin#17](https://user-images.githubusercontent.com/41973452/195725839-eb0c4c9b-9153-4516-aa49-baa2abf0ce26.png)

after:
![dinkplugin#17_2](https://user-images.githubusercontent.com/41973452/195726564-e6915cf4-62fd-4fed-ab1f-6fc5b43951f2.png)
