### PR TITLE
fix: honor notify loot setting for pickpocket and containers

### DIFF
--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -217,11 +217,12 @@ public class DinkPlugin extends Plugin {
 
     @Subscribe
     public void onLootReceived(LootReceived lootReceived) {
-        if (lootReceived.getType() != LootRecordType.EVENT && lootReceived.getType() != LootRecordType.PICKPOCKET) {
-            return;
-        }
+        if (!config.notifyLoot()) return;
 
-        lootNotifier.handleNotify(lootReceived.getItems(), lootReceived.getName());
+        // only consider non-NPC and non-PK loot
+        if (lootReceived.getType() == LootRecordType.EVENT || lootReceived.getType() == LootRecordType.PICKPOCKET) {
+            lootNotifier.handleNotify(lootReceived.getItems(), lootReceived.getName());
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
Loot from pickpocketing and [EVENT](https://github.com/runelite/runelite/blob/9370b8238fe3fad9ff30d9bc58bdd827af5a35df/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java#L993-L1048)'s should not trigger a notification if `notifyLoot` is disabled

Addresses https://github.com/MidgetJake/UniversalDiscordNotifier/issues/16
