### PR TITLE
Fix `PET_REGEX` not matching when you already have a pet out + add tests

### DIFF
--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -73,7 +73,7 @@ public class DinkPlugin extends Plugin {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
-    private static final Pattern PET_REGEX = Pattern.compile("You (have a funny feeling like you|feel something weird).*");
+    public static final Pattern PET_REGEX = Pattern.compile("You (have a funny feeling like you|feel something weird).*");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -73,7 +73,7 @@ public class DinkPlugin extends Plugin {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
-    private static final Pattern PET_REGEX = Pattern.compile("You have a funny feeling like you.*");
+    private static final Pattern PET_REGEX = Pattern.compile("You (have a funny feeling like you|feel something weird).*");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -73,7 +73,7 @@ public class DinkPlugin extends Plugin {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
-    public static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you(?:'re)?|feel something weird sneaking).*");
+    public static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you|feel something weird sneaking).*");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -73,7 +73,7 @@ public class DinkPlugin extends Plugin {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
-    public static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you(?:'re)?|feel something weird).*");
+    public static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you(?:'re)?|feel something weird sneaking).*");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -73,7 +73,7 @@ public class DinkPlugin extends Plugin {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
-    public static final Pattern PET_REGEX = Pattern.compile("You (have a funny feeling like you|feel something weird).*");
+    public static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you(?:'re)?|feel something weird).*");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/test/java/dinkplugin/MatchersTest.kt
+++ b/src/test/java/dinkplugin/MatchersTest.kt
@@ -90,9 +90,9 @@ class MatchersTest {
     @ParameterizedTest(name = "Pet message should trigger {0}")
     @ValueSource(
         strings = [
-            "You have a funny feeling like you're being followed",
-            "You have a funny feeling like you would have been followed",
-            "You feel something weird sneaking into your backpack",
+            "You have a funny feeling like you're being followed.",
+            "You have a funny feeling like you would have been followed...",
+            "You feel something weird sneaking into your backpack.",
         ]
     )
     fun `Pet regex finds match`(message: String) {

--- a/src/test/java/dinkplugin/MatchersTest.kt
+++ b/src/test/java/dinkplugin/MatchersTest.kt
@@ -86,4 +86,30 @@ class MatchersTest {
                 "Lumberjack boots")
         )
     }
+
+    @ParameterizedTest(name = "Pet message should trigger {0}")
+    @ValueSource(
+        strings = [
+            "You have a funny feeling like you're being followed",
+            "You have a funny feeling like you would have been followed",
+            "You feel something weird sneaking into your backpack",
+        ]
+    )
+    fun `Pet regex finds match`(message: String) {
+        val matcher = DinkPlugin.PET_REGEX.matcher(message)
+        assertTrue(matcher.find())
+    }
+
+    @ParameterizedTest(name = "Pet message should not trigger {0}")
+    @ValueSource(
+        strings = [
+            "Forsen: forsen",
+            "You feel like you forgot to turn the stove off",
+        ]
+    )
+    fun `Pet regex does not match`(message: String) {
+        val matcher = DinkPlugin.PET_REGEX.matcher(message)
+        assertFalse(matcher.find())
+    }
+
 }


### PR DESCRIPTION
As noted by [the wiki](https://oldschool.runescape.wiki/w/Pet#Obtaining_a_pet): 
> if a player receives a pet while having a follower out (for example, a cat), it will be placed into their inventory.
> When this occurs, the message in the chatbox will instead state `You feel something weird sneaking into your backpack.`

Currently the regex does not match this variation. This PR updates the regex to match and also makes the regex non-capturing since there's nothing that needs to be captured anyway. Also adds some of those cool tests.

