### PR TITLE
chore: only apply kotlin plugin to test task types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     // runelite has outdated version with CVEs
     implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
 
+    // avoid excluding jetbrains annotations
+    compileOnly(group = "org.jetbrains", name = "annotations", version = "23.0.0")
+
     val runeLiteVersion = "1.9.1"
     compileOnly(group = "net.runelite", name = "client", version = runeLiteVersion)
     testImplementation(group = "net.runelite", name = "client", version = runeLiteVersion)
@@ -39,6 +42,14 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
+}
+
+configurations.compileClasspath {
+    exclude(group = "org.jetbrains.kotlin")
+}
+
+configurations.runtimeClasspath {
+    exclude(group = "org.jetbrains.kotlin")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 
     testImplementation(platform("org.junit:junit-bom:5.9.0"))
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter")
+
+    testImplementation(group = "org.jetbrains.kotlin", name = "kotlin-stdlib")
 }
 
 group = "dinkplugin"
@@ -42,14 +44,6 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
-}
-
-configurations.compileClasspath {
-    exclude(group = "org.jetbrains.kotlin")
-}
-
-configurations.runtimeClasspath {
-    exclude(group = "org.jetbrains.kotlin")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     java
-    id("org.jetbrains.kotlin.jvm") version "1.7.20"
+    id("org.jetbrains.kotlin.jvm") version "1.7.20" apply false
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("io.freefair.lombok") version "6.5.1"
 }
@@ -39,6 +39,10 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
+}
+
+tasks.withType<Test> {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
 }
 
 tasks.test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Only apply the kotlin gradle plugin for the test suite.

Now, kotlin does not appear for any relevant non-test configurations: https://gist.github.com/iProdigy/15f39902dda316bfc631ea4558122c20