### PR TITLE
chore: only enable test suite if DINK_DEBUG

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,6 +10,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DINK_DEBUG: true
+
 jobs:
   gradle:
     strategy:

--- a/.run/Run Dink.run.xml
+++ b/.run/Run Dink.run.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Dink" type="Application" factoryName="Application">
+    <envs>
+      <env name="DINK_DEBUG" value="true" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="dinkplugin.DinkTest" />
     <module name="dinkplugin.test" />
     <option name="PROGRAM_PARAMETERS" value="--debug --developer-mode" />


### PR DESCRIPTION
Require environmental variable `DINK_DEBUG` to be true to reference dependencies not included by runelite
