### PR TITLE
fix: avoid calling webhook before image captured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Bugfix: Ensure send image configs are adhered to. (#51)
 - Dev: Update RuneLite API from v1.9.1 to v1.9.3. (#49)
 - Dev: Fix `@Singular` warning caused by downgrading lombok. (#49)
 

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -65,11 +65,17 @@ public class DiscordMessageHandler {
                     );
                 } catch (IOException e) {
                     log.warn("There was an error creating bytes from captured image", e);
+                } finally {
+                    sendToMultiple(urlList, reqBodyBuilder);
                 }
             });
+        } else {
+            sendToMultiple(urlList, reqBodyBuilder);
         }
+    }
 
-        urlList.forEach(url -> sendMessage(url, reqBodyBuilder));
+    private void sendToMultiple(Collection<HttpUrl> urls, MultipartBody.Builder reqBodyBuilder) {
+        urls.forEach(url -> sendMessage(url, reqBodyBuilder));
     }
 
     private void sendMessage(HttpUrl url, MultipartBody.Builder requestBody) {


### PR DESCRIPTION
Addresses https://github.com/pajlads/DinkPlugin/pull/50#pullrequestreview-1157583396

Race condition was introduced in https://github.com/pajlads/DinkPlugin/pull/39/commits/c38d14c83f2c0e191236300d900ebc0486fce31f