### PR TITLE
Make old kotlin test methods camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bugfix: Ensure send image configs are adhered to. (#51)
 - Dev: Update RuneLite API from v1.9.1 to v1.9.3. (#49)
 - Dev: Fix `@Singular` warning caused by downgrading lombok. (#49)
+- Dev: camelCase test methods. (#52)
+- Dev: Remove leftover `gradle.properties` file. (#52)
 
 ## 1.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
 
 - Bugfix: Ensure send image configs are adhered to. (#51)
-- Dev: Update RuneLite API from v1.9.1 to v1.9.3. (#49)
-- Dev: Fix `@Singular` warning caused by downgrading lombok. (#49)
 - Dev: camelCase test methods. (#52)
 - Dev: Remove leftover `gradle.properties` file. (#52)
+- Dev: Update RuneLite API from v1.9.1 to v1.9.3. (#49)
+- Dev: Fix `@Singular` warning caused by downgrading lombok. (#49)
 
 ## 1.0.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-kotlin.stdlib.default.dependency=false

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -18,13 +18,13 @@ class MatchersTest {
 
     @ParameterizedTest(name = "Slayer task completion message should trigger {0}")
     @ArgumentsSource(SlayerTaskProvider.class)
-    void SlayerTaskCompletionRegexFindsMatch(String message, String task) {
+    void slayerTaskCompletionRegexFindsMatch(String message, String task) {
         Matcher matcher = SlayerNotifier.SLAYER_TASK_REGEX.matcher(message);
         assertTrue(matcher.find());
         assertEquals(task, matcher.group("task"));
     }
 
-    @ParameterizedTest(name = "Slayer task completion message should trigger {0}")
+    @ParameterizedTest(name = "Slayer task completion message should not trigger {0}")
     @ValueSource(
         strings = {
             "Forsen: forsen",
@@ -32,7 +32,7 @@ class MatchersTest {
             "You've completed 234 tasks and received 15 points, giving you a total of 801; return to a Slayer master."
         }
     )
-    void SlayerTaskCompletionRegexDoesNotMatch(String message) {
+    void slayerTaskCompletionRegexDoesNotMatch(String message) {
         Matcher matcher = SlayerNotifier.SLAYER_TASK_REGEX.matcher(message);
         assertFalse(matcher.find());
     }
@@ -74,7 +74,7 @@ class MatchersTest {
             "Forsen: forsen" // todo: add more bad examples
         }
     )
-    void CollectionLogRegexDoesNotMatch(String message) {
+    void collectionLogRegexDoesNotMatch(String message) {
         Matcher matcher = CollectionNotifier.COLLECTION_LOG_REGEX.matcher(message);
         assertFalse(matcher.find());
     }
@@ -107,7 +107,7 @@ class MatchersTest {
             "You feel something weird sneaking into your backpack."
         }
     )
-    void PetRegexFindsMatch(String message) {
+    void petRegexFindsMatch(String message) {
         Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
         assertTrue(matcher.find());
     }
@@ -119,7 +119,7 @@ class MatchersTest {
             "You feel like you forgot to turn the stove off"
         }
     )
-    void PetRegexDoesNotMatch(String message) {
+    void petRegexDoesNotMatch(String message) {
         Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
         assertFalse(matcher.find());
     }


### PR DESCRIPTION
- Made the old kotlin test methods that were migrated to java be in camelCase.
- Fixed the name for a test to properly be "should not trigger".
- Removed unneeded `gradle.properties` file