### PR TITLE
fix: prevent old state from appearing in later notifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Major: Add additional information for PvP deaths. (#55)
 - Major: Add boss kill count notifications. (#50)
 - Minor: Add config to ignore slayer tasks with low point values. (#61)
+- Bugfix: Prevent old clue or slayer data from entering later notifications. (#68)
 - Dev: Add plugin-hub icon. (#65)
 
 ## 1.0.3

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -107,6 +107,7 @@ public class DinkPlugin extends Plugin {
 
     @Subscribe
     public void onGameTick(GameTick event) {
+        clueNotifier.onTick();
         levelNotifier.onTick();
     }
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -108,6 +108,7 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onGameTick(GameTick event) {
         clueNotifier.onTick();
+        slayerNotifier.onTick();
         levelNotifier.onTick();
     }
 

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -31,6 +31,7 @@ public class ClueNotifier extends BaseNotifier {
     private boolean clueCompleted = false;
     private String clueCount = "";
     private String clueType = "";
+    private int badTicks = 0;
 
     public ClueNotifier(DinkPlugin plugin) {
         super(plugin);
@@ -84,6 +85,14 @@ public class ClueNotifier extends BaseNotifier {
         }
     }
 
+    public void onTick() {
+        if (clueCount == null != clueItems.isEmpty()) // XOR
+            badTicks++;
+
+        if (badTicks > 8)
+            reset();
+    }
+
     private void handleNotify() {
         StringBuilder lootMessage = new StringBuilder();
         AtomicLong totalPrice = new AtomicLong();
@@ -130,5 +139,6 @@ public class ClueNotifier extends BaseNotifier {
         this.clueCount = "";
         this.clueType = "";
         this.clueItems.clear();
+        this.badTicks = 0;
     }
 }

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -87,7 +87,7 @@ public class ClueNotifier extends BaseNotifier {
 
     public void onTick() {
         // Track how many ticks occur where we only have partial clue data
-        if (clueCount == null != clueItems.isEmpty()) // XOR
+        if (clueCount.isEmpty() != clueItems.isEmpty()) // XOR
             badTicks++;
 
         // Clear data if over 8 ticks pass with only partial parsing

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -31,7 +31,7 @@ public class ClueNotifier extends BaseNotifier {
     private boolean clueCompleted = false;
     private String clueCount = "";
     private String clueType = "";
-    private int badTicks = 0;
+    private int badTicks = 0; // used to prevent notifs from using stale data
 
     public ClueNotifier(DinkPlugin plugin) {
         super(plugin);
@@ -86,9 +86,11 @@ public class ClueNotifier extends BaseNotifier {
     }
 
     public void onTick() {
+        // Track how many ticks occur where we only have partial clue data
         if (clueCount == null != clueItems.isEmpty()) // XOR
             badTicks++;
 
+        // Clear data if over 8 ticks pass with only partial parsing
         if (badTicks > 8)
             reset();
     }

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -20,6 +20,8 @@ public class SlayerNotifier extends BaseNotifier {
     private String slayerPoints = "";
     private String slayerCompleted = "";
 
+    private int badTicks = 0;
+
     @Inject
     public SlayerNotifier(DinkPlugin plugin) {
         super(plugin);
@@ -64,6 +66,14 @@ public class SlayerNotifier extends BaseNotifier {
         }
     }
 
+    public void onTick() {
+        if (slayerTask.isEmpty() != slayerPoints.isEmpty())
+            badTicks++;
+
+        if (badTicks > 8)
+            reset();
+    }
+
     private void handleNotify() {
         // Little jank, but it's a bit cleaner than having bools and checking in the main plugin class
         if (slayerPoints.isEmpty() || slayerTask.isEmpty() || slayerCompleted.isEmpty()) {
@@ -85,8 +95,13 @@ public class SlayerNotifier extends BaseNotifier {
                 .build());
         }
 
+        this.reset();
+    }
+
+    private void reset() {
         slayerTask = "";
         slayerPoints = "";
         slayerCompleted = "";
+        badTicks = 0;
     }
 }

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -17,9 +17,6 @@ public class SlayerNotifier extends BaseNotifier {
     private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     private String slayerTask = "";
-    private String slayerPoints = "";
-    private String slayerCompleted = "";
-
     private int badTicks = 0; // used to prevent notifs from using stale data
 
     @Inject
@@ -41,7 +38,6 @@ public class SlayerNotifier extends BaseNotifier {
             Matcher taskMatcher = SLAYER_TASK_REGEX.matcher(chatMessage);
             if (taskMatcher.find()) {
                 this.slayerTask = taskMatcher.group("task");
-                this.handleNotify();
                 return;
             }
 
@@ -58,26 +54,23 @@ public class SlayerNotifier extends BaseNotifier {
                 if (slayerPoints == null) {
                     slayerPoints = "0";
                 }
-                this.slayerPoints = slayerPoints;
-                this.slayerCompleted = slayerTasksCompleted;
 
-                this.handleNotify();
+                this.handleNotify(slayerPoints, slayerTasksCompleted);
             }
         }
     }
 
     public void onTick() {
         // Track how many ticks occur where we only have partial slayer data
-        if (slayerTask.isEmpty() != slayerPoints.isEmpty())
+        if (!slayerTask.isEmpty())
             badTicks++;
 
-        // Clear data if over 8 ticks pass with only partial parsing
-        if (badTicks > 8)
+        // Clear data if 2 ticks pass with only partial parsing
+        if (badTicks > 1)
             reset();
     }
 
-    private void handleNotify() {
-        // Little jank, but it's a bit cleaner than having bools and checking in the main plugin class
+    private void handleNotify(String slayerPoints, String slayerCompleted) {
         if (slayerPoints.isEmpty() || slayerTask.isEmpty() || slayerCompleted.isEmpty()) {
             return;
         }
@@ -102,8 +95,6 @@ public class SlayerNotifier extends BaseNotifier {
 
     private void reset() {
         slayerTask = "";
-        slayerPoints = "";
-        slayerCompleted = "";
         badTicks = 0;
     }
 }

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -20,7 +20,7 @@ public class SlayerNotifier extends BaseNotifier {
     private String slayerPoints = "";
     private String slayerCompleted = "";
 
-    private int badTicks = 0;
+    private int badTicks = 0; // used to prevent notifs from using stale data
 
     @Inject
     public SlayerNotifier(DinkPlugin plugin) {
@@ -67,9 +67,11 @@ public class SlayerNotifier extends BaseNotifier {
     }
 
     public void onTick() {
+        // Track how many ticks occur where we only have partial slayer data
         if (slayerTask.isEmpty() != slayerPoints.isEmpty())
             badTicks++;
 
+        // Clear data if over 8 ticks pass with only partial parsing
         if (badTicks > 8)
             reset();
     }


### PR DESCRIPTION
Closes #62

Intuition: clue and slayer notifiers require two event calls to gather all of the data to create the notification. It is possible for only one of these events to be accurately parsed (e.g., transient network issue or too strict regex). As a result, when the next event occurs, it will notify using partially old data. To avoid this, if the notifier is in a partially-parsed state for 2+ ticks, we clear the data (as it does not appear that the complementary event will occur). 

This can be seen as a hotfix while we investigate why the complementary event sometimes is not successfully parsed (or possibly doesn't arrive)

Note: we also simplify the event handling based on the order in which the two events are supposed to be received
