### PR TITLE
Add info about requiring the rs setting to be enabled for Collection Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Major: Add additional information for PvP deaths. (#55)
 - Major: Add boss kill count notifications. (#50)
 - Minor: Add config to ignore slayer tasks with low point values. (#61)
+- Minor: Add note about Collection Log requiring in-game setting (#70)
 - Dev: Add plugin-hub icon. (#65)
 
 ## 1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - Major: Add combat achievement notifications. (#63)
 - Major: Add additional information for PvP deaths. (#55)
 - Major: Add boss kill count notifications. (#50)
-- Minor: Add config to ignore slayer tasks with low point values. (#61)
 - Minor: Add note about Collection Log requiring in-game setting (#70)
+- Minor: Add config to ignore slayer tasks with low point values. (#61)
 - Dev: Add plugin-hub icon. (#65)
 
 ## 1.0.3

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -98,7 +98,8 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "collectionLogEnabled",
         name = "Enable collection log",
-        description = "Enable notifications for collection log",
+        description = "Enable notifications for collection log.<br/>" +
+            "Requires 'Chat > Collection log - New addition notification' setting to be enabled",
         position = 1,
         section = collectionSection
     )


### PR DESCRIPTION
I spent way too much time to finally just add a fucking tooltip line.