### PR TITLE
fix: initialize current levels if plugin was disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Avoid level notifier edge cases related to plugin toggling. (#83)
+
 ## 1.1.1
 
 - Minor: Use notifier-specific screenshot filenames. (#79)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -59,11 +59,16 @@ public class DinkPlugin extends Plugin {
     @Override
     protected void startUp() {
         log.info("Started up Dink");
+        levelNotifier.initLevels();
     }
 
     @Override
     protected void shutDown() {
         log.info("Shutting down Dink");
+        clueNotifier.reset();
+        diaryNotifier.reset();
+        levelNotifier.reset();
+        slayerNotifier.reset();
     }
 
     @Provides

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -132,7 +132,7 @@ public class ClueNotifier extends BaseNotifier {
         return String.format("%s x %s (%s)", item.getQuantity(), item.getName(), QuantityFormatter.quantityToStackSize(item.getTotalPrice()));
     }
 
-    private void reset() {
+    public void reset() {
         this.clueCount = "";
         this.clueType = "";
         this.badTicks = 0;

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -8,6 +8,7 @@ import dinkplugin.notifiers.data.LevelNotificationData;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
+import net.runelite.api.Skill;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.StatChanged;
 import org.apache.commons.lang3.StringUtils;
@@ -32,12 +33,23 @@ public class LevelNotifier extends BaseNotifier {
         return config.levelWebhook();
     }
 
+    public void initLevels() {
+        if (client.getGameState() != GameState.LOGGED_IN) return;
+        for (Skill skill : Skill.values()) {
+            currentLevels.put(skill.getName(), Experience.getLevelForXp(client.getSkillExperience(skill)));
+        }
+    }
+
     public void reset() {
         currentLevels.clear();
         levelledSkills.clear();
     }
 
     public void onTick() {
+        if (currentLevels.isEmpty()) {
+            initLevels();
+        }
+
         if (!sendMessage) {
             return;
         }

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -36,7 +36,9 @@ public class LevelNotifier extends BaseNotifier {
     public void initLevels() {
         if (client.getGameState() != GameState.LOGGED_IN) return;
         for (Skill skill : Skill.values()) {
-            currentLevels.put(skill.getName(), Experience.getLevelForXp(client.getSkillExperience(skill)));
+            if (skill != Skill.OVERALL) {
+                currentLevels.put(skill.getName(), Experience.getLevelForXp(client.getSkillExperience(skill)));
+            }
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -96,7 +96,7 @@ public class SlayerNotifier extends BaseNotifier {
         this.reset();
     }
 
-    private void reset() {
+    public void reset() {
         slayerTask = "";
         badTicks = 0;
     }


### PR DESCRIPTION
Better handle plugin enable/disable: on disable, clear out saved state. on enable, query the latest skill levels for level notifier to function. 

&nbsp;

Resolves edge case before this patch where no level notification would be fired (because `currentLevels` was not initialized) when:
1. Player logs into game with Dink disabled
2. Dink is enabled
3. Player does single action that earns enough xp to trigger level up

&nbsp;

Another resolved edge case:
1. Player disables Dink
2. Player earns levels (or switches to another account with higher levels)
3. Player enables Dink
4. On next experience gain, level up notification would be fired, even if the incremental experience gain was not a full level
