### PR TITLE
chore: add warning logs for bad runescape settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Dev: Add warning logs for improper runescape settings that impact notifiers. (#92)
+- Minor: Add warning logs for improper runescape settings that impact notifiers. (#92)
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Add warning logs for improper runescape settings that impact notifiers. (#92)
+
 ## 1.1.2
 
 - Minor: Add loot notifier setting to ignore player loot. (#82)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -53,8 +53,8 @@ import java.awt.Color;
 )
 public class DinkPlugin extends Plugin {
 
-    private static final Color PINK = ColorUtil.fromHex("#eba2c0");
-    private static final Color RED = ColorUtil.fromHex("#f09d9e");
+    private static final Color PINK = ColorUtil.fromHex("#f40098"); // analogous to RED in CIELCh_uv color space
+    private static final Color RED = ColorUtil.fromHex("#ca2a2d"); // red used in pajaW
 
     private @Inject Client client;
     private @Inject ClientThread clientThread;

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -190,12 +190,14 @@ public class DinkPlugin extends Plugin {
     public void onVarbitChanged(VarbitChanged event) {
         diaryNotifier.onVarbitChanged(event);
 
-        if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && event.getValue() > 0 && config.notifyCombatTask()) {
-            log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
-        }
+        if (client.getGameState() == GameState.LOGGED_IN) {
+            if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && event.getValue() > 0 && config.notifyCombatTask()) {
+                log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
+            }
 
-        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && event.getValue() % 2 != 1 && config.notifyCollectionLog()) {
-            log.warn("Collection log addition chat notifications are not enabled in RuneScape settings; Dink Collection notifier will not fire.");
+            if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && event.getValue() % 2 != 1 && config.notifyCollectionLog()) {
+                log.warn("Collection log addition chat notifications are not enabled in RuneScape settings; Dink Collection notifier will not fire.");
+            }
         }
     }
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -27,6 +27,7 @@ import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.UsernameChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -48,6 +49,7 @@ import javax.inject.Inject;
 public class DinkPlugin extends Plugin {
 
     private @Inject Client client;
+    private @Inject ClientThread clientThread;
 
     private @Inject CollectionNotifier collectionNotifier;
     private @Inject PetNotifier petNotifier;
@@ -92,19 +94,24 @@ public class DinkPlugin extends Plugin {
         GameState gameState = client.getGameState();
 
         if ("combatTaskEnabled".equals(key) && "true".equals(value) && gameState == GameState.LOGGED_IN) {
-            if (client.getVarbitValue(Varbits.COMBAT_ACHIEVEMENTS_POPUP) < 1) {
-                log.warn("Combat Achievements popup is not enabled in RuneScape settings; Dink Combat Task notifier will not fire.");
-            }
+            clientThread.invokeLater(() -> {
+                if (client.getVarbitValue(Varbits.COMBAT_ACHIEVEMENTS_POPUP) < 1) {
+                    log.warn("Combat Achievements popup is not enabled in RuneScape settings; Dink Combat Task notifier will not fire.");
+                }
 
-            if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
-                log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
-            }
+                if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
+                    log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
+                }
+            });
+            return;
         }
 
         if ("collectionLogEnabled".equals(key) && "true".equals(value) && gameState == GameState.LOGGED_IN) {
-            if (client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION) % 2 != 1) {
-                log.warn("Collection log addition chat notifications are not enabled in RuneScape settings; Dink Collection notifier will not fire.");
-            }
+            clientThread.invokeLater(() -> {
+                if (client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION) % 2 != 1) {
+                    log.warn("Collection log addition chat notifications are not enabled in RuneScape settings; Dink Collection notifier will not fire.");
+                }
+            });
         }
     }
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -95,10 +95,6 @@ public class DinkPlugin extends Plugin {
 
         if ("combatTaskEnabled".equals(key) && "true".equals(value) && gameState == GameState.LOGGED_IN) {
             clientThread.invokeLater(() -> {
-                if (client.getVarbitValue(Varbits.COMBAT_ACHIEVEMENTS_POPUP) < 1) {
-                    log.warn("Combat Achievements popup is not enabled in RuneScape settings; Dink Combat Task notifier will not fire.");
-                }
-
                 if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
                     log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
                 }

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -107,7 +107,7 @@ public class DinkPlugin extends Plugin {
         if ("combatTaskEnabled".equals(key) && "true".equals(value) && gameState == GameState.LOGGED_IN) {
             clientThread.invokeLater(() -> {
                 if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
-                    addChatWarning("Combat Task notifier will fire duplicates unless you disable the game setting: Combat Achievement Tasks - Repeat completion");
+                    addChatWarning(CombatTaskNotifier.REPEAT_WARNING);
                 }
             });
             return;
@@ -116,7 +116,7 @@ public class DinkPlugin extends Plugin {
         if ("collectionLogEnabled".equals(key) && "true".equals(value) && gameState == GameState.LOGGED_IN) {
             clientThread.invokeLater(() -> {
                 if (client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION) % 2 != 1) {
-                    addChatWarning("Collection notifier will not fire unless you enable the game setting: Collection log - New addition notification");
+                    addChatWarning(CollectionNotifier.ADDITION_WARNING);
                 }
             });
         }
@@ -192,11 +192,19 @@ public class DinkPlugin extends Plugin {
 
         if (client.getGameState() == GameState.LOGGED_IN) {
             if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && event.getValue() > 0 && config.notifyCombatTask()) {
-                log.warn("Repeat popups for Combat Achievements is enabled; Dink Combat Task notifier will repeatedly fire on each completion.");
+                if (Utils.isSettingsOpen(client)) {
+                    addChatWarning(CombatTaskNotifier.REPEAT_WARNING);
+                } else {
+                    log.warn(CombatTaskNotifier.REPEAT_WARNING);
+                }
             }
 
             if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && event.getValue() % 2 != 1 && config.notifyCollectionLog()) {
-                log.warn("Collection log addition chat notifications are not enabled in RuneScape settings; Dink Collection notifier will not fire.");
+                if (Utils.isSettingsOpen(client)) {
+                    addChatWarning(CollectionNotifier.ADDITION_WARNING);
+                } else {
+                    log.warn(CollectionNotifier.ADDITION_WARNING);
+                }
             }
         }
     }

--- a/src/main/java/dinkplugin/SettingsValidator.java
+++ b/src/main/java/dinkplugin/SettingsValidator.java
@@ -33,7 +33,7 @@ class SettingsValidator {
 
         if ("combatTaskEnabled".equals(key) && "true".equals(value)) {
             clientThread.invokeLater(() -> {
-                if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
+                if (isRepeatPopupInvalid(client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP))) {
                     plugin.addChatWarning(CombatTaskNotifier.REPEAT_WARNING);
                 }
             });
@@ -42,8 +42,7 @@ class SettingsValidator {
 
         if ("collectionLogEnabled".equals(key) && "true".equals(value)) {
             clientThread.invokeLater(() -> {
-                int colLogOption = client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION);
-                if (colLogOption != 1 && colLogOption != 3) {
+                if (isCollectionLogInvalid(client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION))) {
                     plugin.addChatWarning(CollectionNotifier.ADDITION_WARNING);
                 }
             });
@@ -51,12 +50,13 @@ class SettingsValidator {
     }
 
     void onVarbitChanged(VarbitChanged event) {
-        if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && event.getValue() > 0 && config.notifyCombatTask()) {
+        int value = event.getValue();
+
+        if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && isRepeatPopupInvalid(value) && config.notifyCombatTask()) {
             warnForGameSetting(CombatTaskNotifier.REPEAT_WARNING);
         }
 
-        int value = event.getValue();
-        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && value != 1 && value != 3 && config.notifyCollectionLog()) {
+        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && isCollectionLogInvalid(value) && config.notifyCollectionLog()) {
             warnForGameSetting(CollectionNotifier.ADDITION_WARNING);
         }
     }
@@ -67,5 +67,15 @@ class SettingsValidator {
         } else {
             log.warn(message);
         }
+    }
+
+    private static boolean isCollectionLogInvalid(int varbitValue) {
+        // we require chat notification for collection log notifier
+        return varbitValue != 1 && varbitValue != 3;
+    }
+
+    private static boolean isRepeatPopupInvalid(int varbitValue) {
+        // we discourage repeat notifications for combat task notifier if unintentional
+        return varbitValue > 0;
     }
 }

--- a/src/main/java/dinkplugin/SettingsValidator.java
+++ b/src/main/java/dinkplugin/SettingsValidator.java
@@ -1,0 +1,69 @@
+package dinkplugin;
+
+import dinkplugin.notifiers.CollectionNotifier;
+import dinkplugin.notifiers.CombatTaskNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.events.ConfigChanged;
+
+import javax.inject.Inject;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = { @Inject })
+class SettingsValidator {
+    private static final String CONFIG_GROUP = "dinkplugin";
+
+    private final Client client;
+    private final ClientThread clientThread;
+    private final DinkPlugin plugin;
+    private final DinkPluginConfig config;
+
+    void onConfigChanged(ConfigChanged event) {
+        if (!CONFIG_GROUP.equals(event.getGroup()) || client.getGameState() != GameState.LOGGED_IN) {
+            return;
+        }
+
+        String key = event.getKey();
+        String value = event.getNewValue();
+
+        if ("combatTaskEnabled".equals(key) && "true".equals(value)) {
+            clientThread.invokeLater(() -> {
+                if (client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP) > 0) {
+                    plugin.addChatWarning(CombatTaskNotifier.REPEAT_WARNING);
+                }
+            });
+            return;
+        }
+
+        if ("collectionLogEnabled".equals(key) && "true".equals(value)) {
+            clientThread.invokeLater(() -> {
+                if (client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION) % 2 != 1) {
+                    plugin.addChatWarning(CollectionNotifier.ADDITION_WARNING);
+                }
+            });
+        }
+    }
+
+    void onVarbitChanged(VarbitChanged event) {
+        if (event.getVarbitId() == CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP && event.getValue() > 0 && config.notifyCombatTask()) {
+            warnForGameSetting(CombatTaskNotifier.REPEAT_WARNING);
+        }
+
+        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && event.getValue() % 2 != 1 && config.notifyCollectionLog()) {
+            warnForGameSetting(CollectionNotifier.ADDITION_WARNING);
+        }
+    }
+
+    private void warnForGameSetting(String message) {
+        if (Utils.isSettingsOpen(client)) {
+            plugin.addChatWarning(message);
+        } else {
+            log.warn(message);
+        }
+    }
+}

--- a/src/main/java/dinkplugin/SettingsValidator.java
+++ b/src/main/java/dinkplugin/SettingsValidator.java
@@ -42,7 +42,8 @@ class SettingsValidator {
 
         if ("collectionLogEnabled".equals(key) && "true".equals(value)) {
             clientThread.invokeLater(() -> {
-                if (client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION) % 2 != 1) {
+                int colLogOption = client.getVarbitValue(Varbits.COLLECTION_LOG_NOTIFICATION);
+                if (colLogOption != 1 && colLogOption != 3) {
                     plugin.addChatWarning(CollectionNotifier.ADDITION_WARNING);
                 }
             });
@@ -54,7 +55,8 @@ class SettingsValidator {
             warnForGameSetting(CombatTaskNotifier.REPEAT_WARNING);
         }
 
-        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && event.getValue() % 2 != 1 && config.notifyCollectionLog()) {
+        int value = event.getValue();
+        if (event.getVarbitId() == Varbits.COLLECTION_LOG_NOTIFICATION && value != 1 && value != 3 && config.notifyCollectionLog()) {
             warnForGameSetting(CollectionNotifier.ADDITION_WARNING);
         }
     }

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -15,10 +15,12 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
+import net.runelite.client.util.ColorUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.imageio.ImageIO;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,6 +43,9 @@ import java.util.stream.Stream;
 import static net.runelite.api.ItemID.*;
 
 public class Utils {
+
+    public static final Color PINK = ColorUtil.fromHex("#f40098"); // analogous to RED in CIELCh_uv color space
+    public static final Color RED = ColorUtil.fromHex("#ca2a2d"); // red used in pajaW
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -125,6 +125,11 @@ public class Utils {
         return SOUL_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID());
     }
 
+    public static boolean isSettingsOpen(@NotNull Client client) {
+        Widget widget = client.getWidget(WidgetInfo.SETTINGS_INIT);
+        return widget != null && !widget.isSelfHidden();
+    }
+
     public static String getPlayerName(Client client) {
         return client.getLocalPlayer().getName();
     }

--- a/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 public class CollectionNotifier extends BaseNotifier {
     @VisibleForTesting
     static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>(.*))");
+    public static final String ADDITION_WARNING = "Collection notifier will not fire unless you enable the game setting: Collection log - New addition notification";
 
     @Override
     public boolean isEnabled() {

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -6,6 +6,7 @@ import dinkplugin.domain.CombatAchievementTier;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.CombatAchievementData;
+import net.runelite.api.annotations.Varbit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -16,6 +17,9 @@ import java.util.regex.Pattern;
 
 public class CombatTaskNotifier extends BaseNotifier {
     private static final Pattern ACHIEVEMENT_PATTERN = Pattern.compile("Congratulations, you've completed an? (?<tier>\\w+) combat task: (?<task>.+)\\.");
+
+    @Varbit
+    public static final int COMBAT_TASK_REPEAT_POPUP = 12456;
 
     @Override
     public boolean isEnabled() {

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 
 public class CombatTaskNotifier extends BaseNotifier {
     private static final Pattern ACHIEVEMENT_PATTERN = Pattern.compile("Congratulations, you've completed an? (?<tier>\\w+) combat task: (?<task>.+)\\.");
+    public static final String REPEAT_WARNING = "Combat Task notifier will fire duplicates unless you disable the game setting: Combat Achievement Tasks - Repeat completion";
 
     @Varbit
     public static final int COMBAT_TASK_REPEAT_POPUP = 12456;


### PR DESCRIPTION
* Collection log notifier requires `COLLECTION_LOG_NOTIFICATION` = 1 or 3
* If `COMBAT_TASK_REPEAT_POPUP` is enabled, warn that combat task will keep sending notifications on each repeated event
