### PR TITLE
feat: retry failed webhook messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Retry failed webhook messages with exponential backoff. (#94)
+
 ## 1.1.2
 
 - Minor: Add loot notifier setting to ignore player loot. (#82)

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -103,6 +103,28 @@ public interface DinkPluginConfig extends Config {
     String diarySection = "Achievement Diary";
 
     @ConfigItem(
+        keyName = "maxRetries",
+        name = "Webhook Max Retries",
+        description = "The maximum number of retry attempts for sending a webhook message. Negative implies no attempts",
+        position = -100,
+        hidden = true
+    )
+    default int maxRetries() {
+        return 5;
+    }
+
+    @ConfigItem(
+        keyName = "baseRetryDelay",
+        name = "Webhook Retry Base Delay",
+        description = "The base number of milliseconds to wait before attempting a retry for a webhook message",
+        position = -99,
+        hidden = true
+    )
+    default long baseRetryDelay() {
+        return 1000L;
+    }
+
+    @ConfigItem(
         keyName = "discordWebhook", // do not rename; would break old configs
         name = "Primary Webhook URLs",
         description = "The default webhook URL to send notifications to, if no override is specified.<br/>" +

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -110,7 +110,7 @@ public interface DinkPluginConfig extends Config {
         hidden = true
     )
     default int maxRetries() {
-        return 5;
+        return 3;
     }
 
     @ConfigItem(
@@ -121,7 +121,7 @@ public interface DinkPluginConfig extends Config {
         hidden = true
     )
     default long baseRetryDelay() {
-        return 1000L;
+        return 2000L;
     }
 
     @ConfigItem(


### PR DESCRIPTION
Workaround for https://i.imgur.com/SMOGZ8J.png 

By default, retries will occur:  2s after initial failure, 4s after next, 8s after next ~~1s after initial failure, 2s after next fail, 4s after next, 8s after next, 16s after next (i.e., over 30s after the initial attempt, cumulatively)... i'm also open to changing the default values governing this~~
