### PR TITLE
fix: increase timeout when writing screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Retry failed webhook messages with exponential backoff. (#94)
+- Bugfix: Reduce timeouts from uploading screenshots on slow connections. (#96)
 
 ## 1.1.2
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -24,6 +24,7 @@ import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.UsernameChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
@@ -42,6 +43,7 @@ import javax.inject.Inject;
     tags = { "loot", "logger", "collection", "pet", "death", "xp", "level", "notifications", "discord", "speedrun" }
 )
 public class DinkPlugin extends Plugin {
+    public static final String USER_AGENT = "Dink/1.x " + RuneLite.USER_AGENT;
 
     private @Inject CollectionNotifier collectionNotifier;
     private @Inject PetNotifier petNotifier;

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -43,7 +43,7 @@ import javax.inject.Inject;
     tags = { "loot", "logger", "collection", "pet", "death", "xp", "level", "notifications", "discord", "speedrun" }
 )
 public class DinkPlugin extends Plugin {
-    public static final String USER_AGENT = "Dink/1.x " + RuneLite.USER_AGENT;
+    public static final String USER_AGENT = RuneLite.USER_AGENT + " (Dink/1.x)";
 
     private @Inject CollectionNotifier collectionNotifier;
     private @Inject PetNotifier petNotifier;

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -102,12 +102,20 @@ public interface DinkPluginConfig extends Config {
     )
     String diarySection = "Achievement Diary";
 
+    @ConfigSection(
+        name = "Advanced",
+        description = "Do not modify without fully understanding these settings",
+        position = 1000,
+        closedByDefault = true
+    )
+    String advancedSection = "Advanced";
+
     @ConfigItem(
         keyName = "maxRetries",
         name = "Webhook Max Retries",
         description = "The maximum number of retry attempts for sending a webhook message. Negative implies no attempts",
-        position = -100,
-        hidden = true
+        position = 1000,
+        section = advancedSection
     )
     default int maxRetries() {
         return 3;
@@ -117,19 +125,19 @@ public interface DinkPluginConfig extends Config {
         keyName = "baseRetryDelay",
         name = "Webhook Retry Base Delay",
         description = "The base number of milliseconds to wait before attempting a retry for a webhook message",
-        position = -99,
-        hidden = true
+        position = 1001,
+        section = advancedSection
     )
-    default long baseRetryDelay() {
-        return 2000L;
+    default int baseRetryDelay() {
+        return 2000;
     }
 
     @ConfigItem(
         keyName = "imageWriteTimeout",
         name = "Image Upload Timeout",
         description = "The maximum number of seconds that uploading a screenshot can take before timing out",
-        position = -98,
-        hidden = true
+        position = 1002,
+        section = advancedSection
     )
     default int imageWriteTimeout() {
         return 30; // elevated from okhttp default of 10

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -125,6 +125,17 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "imageWriteTimeout",
+        name = "Image Upload Timeout",
+        description = "The maximum number of seconds that uploading a screenshot can take before timing out",
+        position = -98,
+        hidden = true
+    )
+    default int imageWriteTimeout() {
+        return 30; // elevated from okhttp default of 10
+    }
+
+    @ConfigItem(
         keyName = "discordWebhook", // do not rename; would break old configs
         name = "Primary Webhook URLs",
         description = "The default webhook URL to send notifications to, if no override is specified.<br/>" +

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -15,6 +15,8 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -183,6 +185,13 @@ public class Utils {
             .map(NotificationBody.UrlEmbed::new)
             .map(NotificationBody.Embed::new)
             .collect(Collectors.toList());
+    }
+
+    public static boolean hasImage(@NotNull MultipartBody body) {
+        return body.parts().stream().anyMatch(part -> {
+            MediaType type = part.body().contentType();
+            return type != null && "image".equals(type.type());
+        });
     }
 
     // Credit to: https://github.com/oliverpatrick/Enhanced-Discord-Notifications/blob/master/src/main/java/com/enhanceddiscordnotifications/EnhancedDiscordNotificationsPlugin.java

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -56,7 +56,7 @@ public class DiscordMessageHandler {
                 Interceptor.Chain updatedChain = chain;
                 // Allow longer timeout when writing a screenshot file to overcome slow internet speeds
                 if (request.body() instanceof MultipartBody && Utils.hasImage((MultipartBody) request.body())) {
-                    updatedChain = chain.withWriteTimeout(30, TimeUnit.SECONDS); // default is 10 seconds
+                    updatedChain = chain.withWriteTimeout(Math.max(config.imageWriteTimeout(), 0), TimeUnit.SECONDS);
                 }
                 return updatedChain.proceed(request);
             })

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -1,5 +1,6 @@
 package dinkplugin.message;
 
+import dinkplugin.DinkPlugin;
 import dinkplugin.DinkPluginConfig;
 import dinkplugin.Utils;
 import lombok.NonNull;
@@ -48,7 +49,9 @@ public class DiscordMessageHandler {
         this.executor = executor;
         this.httpClient = httpClient.newBuilder()
             .addInterceptor(chain -> {
-                Request request = chain.request();
+                Request request = chain.request().newBuilder()
+                    .header("User-Agent", DinkPlugin.USER_AGENT)
+                    .build();
                 Interceptor.Chain updatedChain = chain;
                 // Allow longer timeout when writing a screenshot file to overcome slow internet speeds
                 if (request.body() instanceof MultipartBody && Utils.hasImage((MultipartBody) request.body())) {

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -1,5 +1,6 @@
 package dinkplugin.message;
 
+import com.google.gson.Gson;
 import dinkplugin.DinkPlugin;
 import dinkplugin.DinkPluginConfig;
 import dinkplugin.Utils;
@@ -30,11 +31,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static net.runelite.http.api.RuneLiteAPI.GSON;
-
 @Slf4j
 @Singleton
 public class DiscordMessageHandler {
+    private final Gson gson;
     private final Client client;
     private final DrawManager drawManager;
     private final OkHttpClient httpClient;
@@ -42,7 +42,8 @@ public class DiscordMessageHandler {
     private final ScheduledExecutorService executor;
 
     @Inject
-    public DiscordMessageHandler(Client client, DrawManager drawManager, OkHttpClient httpClient, DinkPluginConfig config, ScheduledExecutorService executor) {
+    public DiscordMessageHandler(Gson gson, Client client, DrawManager drawManager, OkHttpClient httpClient, DinkPluginConfig config, ScheduledExecutorService executor) {
+        this.gson = gson;
         this.client = client;
         this.drawManager = drawManager;
         this.config = config;
@@ -76,7 +77,7 @@ public class DiscordMessageHandler {
 
         MultipartBody.Builder reqBodyBuilder = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("payload_json", GSON.toJson(mBody));
+            .addFormDataPart("payload_json", gson.toJson(mBody));
 
         if (sendImage) {
             drawManager.requestNextFrameListener(image -> {


### PR DESCRIPTION
Default write timeout is 10 seconds. This timeout can be breached for users with slow upload speeds trying to write screenshots of high resolution or detailed (e.g., with HD plugin) environments. This PR raises the write timeout for such calls to 30 seconds. 