### PR TITLE
Better descriptions for `minValue` settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add better descriptions for `Min Value` settings. (#100)
 - Minor: Retry failed webhook messages with exponential backoff. (#94)
 - Dev: Bump mockito version to 4.10.0. (#95)
 

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -414,7 +414,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "minLootValue",
         name = "Min Loot value",
-        description = "Minimum value of the loot for a notification to be sent",
+        description = "The minimum value of an item for a notification to be sent",
         position = 33,
         section = lootSection
     )

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -612,7 +612,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "clueMinValue",
         name = "Min Value",
-        description = "The minimum value of the items for a notification to be sent",
+        description = "The minimum value of the combined items for a notification to be sent",
         position = 73,
         section = clueSection
     )

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -414,7 +414,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "minLootValue",
         name = "Min Loot value",
-        description = "Minimum value of the loot to notify",
+        description = "Minimum value of the loot for a notification to be sent",
         position = 33,
         section = lootSection
     )
@@ -612,7 +612,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "clueMinValue",
         name = "Min Value",
-        description = "The minimum value of the items to be shown",
+        description = "The minimum value of the items for a notification to be sent",
         position = 73,
         section = clueSection
     )


### PR DESCRIPTION
Noticed the sub-par description of `clueMinValue` while testing #98, it took me too long to realize it wasn't talking about minValue for discord embeds.

The `minLootValue` description was better, but I went ahead and updated it anyway.