### PR TITLE
feat: track best fight duration in kill count notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add personal best time message to kill count notifier. (#106)
 - Minor: Add better descriptions for `Min Value` settings. (#100)
 - Minor: Add death notifier setting to disable kept item embeds. (#99)
 - Minor: Add clue and loot notifier setting to skip screenshots for low item values. (#98)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -70,6 +70,7 @@ public class DinkPlugin extends Plugin {
         diaryNotifier.reset();
         levelNotifier.reset();
         slayerNotifier.reset();
+        killCountNotifier.reset();
     }
 
     @Provides
@@ -99,6 +100,7 @@ public class DinkPlugin extends Plugin {
         slayerNotifier.onTick();
         levelNotifier.onTick();
         diaryNotifier.onTick();
+        killCountNotifier.onTick();
     }
 
     @Subscribe

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -116,6 +116,10 @@ public class DinkPlugin extends Plugin {
             killCountNotifier.onGameMessage(chatMessage);
             combatTaskNotifier.onGameMessage(chatMessage);
         }
+
+        if (msgType == ChatMessageType.FRIENDSCHATNOTIFICATION) {
+            killCountNotifier.onFriendsChatNotification(chatMessage);
+        }
     }
 
     @Subscribe

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -106,7 +106,7 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onChatMessage(ChatMessage message) {
         ChatMessageType msgType = message.getType();
-        String chatMessage = Text.removeTags(message.getMessage());
+        String chatMessage = Text.removeTags(message.getMessage().replace("<br>", "\n")).replace('\u00A0', ' ').trim();
 
         if (msgType == ChatMessageType.GAMEMESSAGE) {
             collectionNotifier.onChatMessage(chatMessage);

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -764,10 +764,21 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "killCountPB",
+        name = "Personal Best",
+        description = "Notify on achieving a new personal best time",
+        position = 93,
+        section = killCountSection
+    )
+    default boolean killCountNotifyBestTime() {
+        return true;
+    }
+
+    @ConfigItem(
         keyName = "killCountInterval",
         name = "Kill Count Interval",
         description = "Interval between when a notification should be sent",
-        position = 93,
+        position = 94,
         section = killCountSection
     )
     default int killCountInterval() {
@@ -778,7 +789,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "killCountMessage",
         name = "Notification Message",
         description = "The message to be sent to the webhook. Use %USERNAME% to insert your username, %BOSS% to insert the NPC name, %COUNT% to insert the kill count",
-        position = 94,
+        position = 95,
         section = killCountSection
     )
     default String killCountMessage() {

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -797,6 +797,17 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "killCountBestTimeMessage",
+        name = "PB Notification Message",
+        description = "The message to be sent to the webhook upon a personal best time. Use %USERNAME% to insert your username, %BOSS% to insert the NPC name, %COUNT% to insert the kill count, %TIME% to insert the completion time",
+        position = 96,
+        section = killCountSection
+    )
+    default String killCountBestTimeMessage() {
+        return "%USERNAME% has defeated %BOSS% with a new personal best time of %TIME% and a completion count of %COUNT%";
+    }
+
+    @ConfigItem(
         keyName = "combatTaskEnabled",
         name = "Enable Combat Tasks",
         description = "Enable notifications for combat achievements",

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -22,6 +22,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +42,8 @@ import java.util.stream.Stream;
 import static net.runelite.api.ItemID.*;
 
 public class Utils {
+
+    private static final Pattern TIME_PATTERN = Pattern.compile("\\b(?:(?<hours>\\d+):)?(?<minutes>\\d+):(?<seconds>\\d{2})(?:\\.(?<fractional>\\d{2}))?\\b");
 
     private static final Set<WorldType> IGNORED_WORLDS = EnumSet.of(WorldType.PVP_ARENA, WorldType.QUEST_SPEEDRUNNING, WorldType.NOSAVE_MODE, WorldType.TOURNAMENT_WORLD);
 
@@ -183,6 +186,28 @@ public class Utils {
             .map(NotificationBody.UrlEmbed::new)
             .map(NotificationBody.Embed::new)
             .collect(Collectors.toList());
+    }
+
+    public static Duration parseTime(String in) {
+        Matcher m = TIME_PATTERN.matcher(in);
+        if (!m.find()) return Duration.ZERO;
+
+        int minutes = Integer.parseInt(m.group("minutes"));
+        int seconds = Integer.parseInt(m.group("seconds"));
+
+        Duration d = Duration.ofMinutes(minutes).plusSeconds(seconds);
+
+        String hours = m.group("hours");
+        if (hours != null) {
+            d = d.plusHours(Integer.parseInt(hours));
+        }
+
+        String fractional = m.group("fractional");
+        if (fractional != null) {
+            d = d.plusMillis(Integer.parseInt(fractional) * 10L);
+        }
+
+        return d;
     }
 
     // Credit to: https://github.com/oliverpatrick/Enhanced-Discord-Notifications/blob/master/src/main/java/com/enhanceddiscordnotifications/EnhancedDiscordNotificationsPlugin.java

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -204,6 +204,7 @@ public class Utils {
         return client.getVarbitValue(ENABLE_PRECISE_TIMING) > 0;
     }
 
+    @NotNull
     public static Duration parseTime(String in) {
         Matcher m = TIME_PATTERN.matcher(in);
         if (!m.find()) return Duration.ZERO;
@@ -228,6 +229,7 @@ public class Utils {
         return d;
     }
 
+    @NotNull
     public static String format(@Nullable Duration duration, boolean precise) {
         Temporal time = ObjectUtils.defaultIfNull(duration, Duration.ZERO).addTo(LocalTime.of(0, 0));
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/dinkplugin/Utils.java
+++ b/src/main/java/dinkplugin/Utils.java
@@ -15,7 +15,10 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.imageio.ImageIO;
@@ -23,6 +26,8 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.LocalTime;
+import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +44,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static net.runelite.api.ItemID.*;
 
 public class Utils {
@@ -61,6 +70,9 @@ public class Utils {
     private static final int CASTLE_WARS_X_OFFSET = 156;
     @Varbit
     private static final int CASTLE_WARS_Y_OFFSET = 157;
+
+    @VisibleForTesting
+    public static final @Varbit int ENABLE_PRECISE_TIMING = 11866;
 
     private static final Set<Integer> NEVER_KEPT_ITEMS = ImmutableSet.of(
         CLUE_BOX, LOOTING_BAG,
@@ -188,6 +200,10 @@ public class Utils {
             .collect(Collectors.toList());
     }
 
+    public static boolean isPreciseTiming(Client client) {
+        return client.getVarbitValue(ENABLE_PRECISE_TIMING) > 0;
+    }
+
     public static Duration parseTime(String in) {
         Matcher m = TIME_PATTERN.matcher(in);
         if (!m.find()) return Duration.ZERO;
@@ -204,10 +220,29 @@ public class Utils {
 
         String fractional = m.group("fractional");
         if (fractional != null) {
-            d = d.plusMillis(Integer.parseInt(fractional) * 10L);
+            // osrs sends 2 digits, but this is robust to changes
+            String f = fractional.length() < 3 ? StringUtils.rightPad(fractional, 3, '0') : fractional.substring(0, 3);
+            d = d.plusMillis(Integer.parseInt(f));
         }
 
         return d;
+    }
+
+    public static String format(@Nullable Duration duration, boolean precise) {
+        Temporal time = ObjectUtils.defaultIfNull(duration, Duration.ZERO).addTo(LocalTime.of(0, 0));
+        StringBuilder sb = new StringBuilder();
+
+        int h = time.get(HOUR_OF_DAY);
+        if (h > 0)
+            sb.append(String.format("%02d", h)).append(':');
+
+        sb.append(String.format("%02d", time.get(MINUTE_OF_HOUR))).append(':');
+        sb.append(String.format("%02d", time.get(SECOND_OF_MINUTE)));
+
+        if (precise)
+            sb.append('.').append(String.format("%02d", time.get(MILLI_OF_SECOND) / 10));
+
+        return sb.toString();
     }
 
     // Credit to: https://github.com/oliverpatrick/Enhanced-Discord-Notifications/blob/master/src/main/java/com/enhanceddiscordnotifications/EnhancedDiscordNotificationsPlugin.java

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -50,6 +50,11 @@ public class KillCountNotifier extends BaseNotifier {
             parse(message).ifPresent(this::updateData);
     }
 
+    public void onFriendsChatNotification(String message) {
+        if (message.startsWith("Congratulations - your raid is complete!"))
+            this.onGameMessage(message);
+    }
+
     public void onTick() {
         if (data != null) {
             handleKill(data);

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -7,7 +7,6 @@ import dinkplugin.notifiers.data.BossNotificationData;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.NPC;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -64,7 +63,7 @@ public class KillCountNotifier extends BaseNotifier {
 
         // Assemble content
         String player = Utils.getPlayerName(client);
-        String time = DurationFormatUtils.formatDurationHMS(defaultIfNull(data.getTime(), Duration.ZERO).toMillis());
+        String time = Utils.format(data.getTime(), Utils.isPreciseTiming(client));
         String content = StringUtils.replaceEach(
             data.isPersonalBest() == Boolean.TRUE ? config.killCountBestTimeMessage() : config.killCountMessage(),
             new String[] { "%USERNAME%", "%BOSS%", "%COUNT%", "%TIME%" },

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -7,6 +7,7 @@ import dinkplugin.notifiers.data.BossNotificationData;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.NPC;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -63,10 +64,11 @@ public class KillCountNotifier extends BaseNotifier {
 
         // Assemble content
         String player = Utils.getPlayerName(client);
+        String time = DurationFormatUtils.formatDurationHMS(defaultIfNull(data.getTime(), Duration.ZERO).toMillis());
         String content = StringUtils.replaceEach(
-            config.killCountMessage(),
-            new String[] { "%USERNAME%", "%BOSS%", "%COUNT%" },
-            new String[] { player, data.getBoss(), String.valueOf(data.getCount()) }
+            data.isPersonalBest() == Boolean.TRUE ? config.killCountBestTimeMessage() : config.killCountMessage(),
+            new String[] { "%USERNAME%", "%BOSS%", "%COUNT%", "%TIME%" },
+            new String[] { player, data.getBoss(), String.valueOf(data.getCount()), time }
         );
 
         // Prepare body

--- a/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
@@ -11,12 +11,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.time.Duration;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 public class SpeedrunNotifier extends BaseNotifier {
-    private static final Pattern TIME_PATTERN = Pattern.compile("(?<minutes>\\d+):(?<seconds>\\d{2})\\.(?<fractional>\\d{2})");
     static final @VisibleForTesting int SPEEDRUN_COMPLETED_GROUP_ID = 781;
     static final @VisibleForTesting int SPEEDRUN_COMPLETED_QUEST_NAME_CHILD_ID = 4;
     static final @VisibleForTesting int SPEEDRUN_COMPLETED_DURATION_CHILD_ID = 10;
@@ -46,8 +43,8 @@ public class SpeedrunNotifier extends BaseNotifier {
     }
 
     private void attemptNotify(String questName, String duration, String pb) {
-        Duration bestTime = parseTime(pb);
-        Duration currentTime = parseTime(duration);
+        Duration bestTime = Utils.parseTime(pb);
+        Duration currentTime = Utils.parseTime(duration);
         boolean isPb = bestTime.compareTo(currentTime) >= 0;
         if (!isPb && config.speedrunPBOnly()) {
             return;
@@ -66,15 +63,5 @@ public class SpeedrunNotifier extends BaseNotifier {
             .screenshotFile("speedrunImage.png")
             .type(NotificationType.SPEEDRUN)
             .build());
-    }
-
-    private static Duration parseTime(String in) {
-        Matcher m = TIME_PATTERN.matcher(in);
-        if (!m.find()) return Duration.ofMillis(0);
-        int minutes = Integer.parseInt(m.group("minutes"));
-        int seconds = Integer.parseInt(m.group("seconds"));
-        int fractional = Integer.parseInt(m.group("fractional"));
-        // 0.001
-        return Duration.ofMillis(10L * (100L * (60L * minutes + seconds) + fractional));
     }
 }

--- a/src/main/java/dinkplugin/notifiers/data/BossNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/BossNotificationData.java
@@ -1,10 +1,16 @@
 package dinkplugin.notifiers.data;
 
 import lombok.Value;
+import lombok.experimental.Accessors;
+
+import java.time.Duration;
 
 @Value
 public class BossNotificationData {
     String boss;
     Integer count;
     String gameMessage;
+    Duration time;
+    @Accessors(fluent = true)
+    Boolean isPersonalBest;
 }

--- a/src/main/java/dinkplugin/notifiers/data/BossNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/BossNotificationData.java
@@ -1,5 +1,7 @@
 package dinkplugin.notifiers.data;
 
+import com.google.gson.annotations.JsonAdapter;
+import dinkplugin.util.DurationAdapter;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -10,6 +12,7 @@ public class BossNotificationData {
     String boss;
     Integer count;
     String gameMessage;
+    @JsonAdapter(DurationAdapter.class)
     Duration time;
     @Accessors(fluent = true)
     Boolean isPersonalBest;

--- a/src/main/java/dinkplugin/util/DurationAdapter.java
+++ b/src/main/java/dinkplugin/util/DurationAdapter.java
@@ -8,6 +8,15 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 
+/**
+ * Serializes and deserializes {@link Duration} instances
+ * from their equivalent ISO-8601 string representation.
+ * <p>
+ * This adapter exists because GSON does not ship with
+ * a module for the Java 8 time API.
+ *
+ * @see <a href="https://github.com/google/gson/issues/1059">GSON Issue</>
+ */
 public class DurationAdapter extends TypeAdapter<Duration> {
     @Override
     public void write(JsonWriter out, Duration duration) throws IOException {
@@ -17,9 +26,8 @@ public class DurationAdapter extends TypeAdapter<Duration> {
     @Override
     public Duration read(JsonReader in) throws IOException {
         if (in.hasNext()) {
-            String str = in.nextString();
             try {
-                return Duration.parse(str);
+                return Duration.parse(in.nextString());
             } catch (DateTimeParseException ignored) {
             }
         }

--- a/src/main/java/dinkplugin/util/DurationAdapter.java
+++ b/src/main/java/dinkplugin/util/DurationAdapter.java
@@ -1,0 +1,28 @@
+package dinkplugin.util;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
+public class DurationAdapter extends TypeAdapter<Duration> {
+    @Override
+    public void write(JsonWriter out, Duration duration) throws IOException {
+        out.value(duration != null ? duration.toString() : null);
+    }
+
+    @Override
+    public Duration read(JsonReader in) throws IOException {
+        if (in.hasNext()) {
+            String str = in.nextString();
+            try {
+                return Duration.parse(str);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/dinkplugin/util/DurationAdapter.java
+++ b/src/main/java/dinkplugin/util/DurationAdapter.java
@@ -15,7 +15,7 @@ import java.time.format.DateTimeParseException;
  * This adapter exists because GSON does not ship with
  * a module for the Java 8 time API.
  *
- * @see <a href="https://github.com/google/gson/issues/1059">GSON Issue</>
+ * @see <a href="https://github.com/google/gson/issues/1059">GSON Issue</a>
  */
 public class DurationAdapter extends TypeAdapter<Duration> {
     @Override

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -38,6 +38,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         // fire event
         String gameMessage = "Your King Black Dragon kill count is: 420.";
         notifier.onGameMessage(gameMessage);
+        notifier.onTick();
 
         // check notification
         verify(messageHandler).createMessage(
@@ -61,6 +62,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         // fire event
         String gameMessage = "Your King Black Dragon kill count is: 1.";
         notifier.onGameMessage(gameMessage);
+        notifier.onTick();
 
         // check notification
         verify(messageHandler).createMessage(
@@ -84,6 +86,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         // fire event
         String gameMessage = "Your King Black Dragon kill count is: 1.";
         notifier.onGameMessage(gameMessage);
+        notifier.onTick();
 
         // ensure no message
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -99,6 +102,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         // fire event
         String gameMessage = "Your King Black Dragon kill count is: 1.";
         notifier.onGameMessage(gameMessage);
+        notifier.onTick();
 
         // ensure no message
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -137,6 +137,78 @@ class KillCountNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testNotifyGauntletPb() {
+        // more config
+        when(config.killCountInterval()).thenReturn(99);
+
+        // fire events
+        notifier.onGameMessage("Challenge duration: 10:25 (new personal best).");
+        String gameMessage = "Your Gauntlet completion count is: 10.";
+        notifier.onGameMessage(gameMessage);
+        notifier.onTick();
+
+        // check notification
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            true,
+            NotificationBody.builder()
+                .content(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 00:10:25.000 and a completion count of 10")
+                .extra(new BossNotificationData("Crystalline Hunllef", 10, gameMessage, Duration.ofMinutes(10).plusSeconds(25), true))
+                .playerName(PLAYER_NAME)
+                .type(NotificationType.KILL_COUNT)
+                .build()
+        );
+    }
+
+    @Test
+    void testNotifyTemporossPb() {
+        // more config
+        when(config.killCountInterval()).thenReturn(99);
+
+        // fire events
+        notifier.onGameMessage("Subdued in 6:30 (new personal best).");
+        String gameMessage = "Your Tempoross kill count is: 69.";
+        notifier.onGameMessage(gameMessage);
+        notifier.onTick();
+
+        // check notification
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            true,
+            NotificationBody.builder()
+                .content(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 00:06:30.000 and a completion count of 69")
+                .extra(new BossNotificationData("Tempoross", 69, gameMessage, Duration.ofMinutes(6).plusSeconds(30), true))
+                .playerName(PLAYER_NAME)
+                .type(NotificationType.KILL_COUNT)
+                .build()
+        );
+    }
+
+    @Test
+    void testNotifyTombsPb() {
+        // more config
+        when(config.killCountInterval()).thenReturn(99);
+
+        // fire events
+        notifier.onGameMessage("Tombs of Amascut total completion time: 25:00 (new personal best)");
+        String gameMessage = "Your completed Tombs of Amascut: Expert Mode count is: 8.";
+        notifier.onGameMessage(gameMessage);
+        notifier.onTick();
+
+        // check notification
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            true,
+            NotificationBody.builder()
+                .content(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 00:25:00.000 and a completion count of 8")
+                .extra(new BossNotificationData("Tombs of Amascut: Expert Mode", 8, gameMessage, Duration.ofMinutes(25), true))
+                .playerName(PLAYER_NAME)
+                .type(NotificationType.KILL_COUNT)
+                .build()
+        );
+    }
+
+    @Test
     void testNotifyNoPb() {
         // more config
         when(config.killCountInterval()).thenReturn(6);

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import dinkplugin.Utils;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.BossNotificationData;
@@ -33,6 +34,9 @@ class KillCountNotifierTest extends MockedNotifierTest {
         when(config.killCountSendImage()).thenReturn(true);
         when(config.killCountMessage()).thenReturn("%USERNAME% has defeated %BOSS% with a completion count of %COUNT%");
         when(config.killCountBestTimeMessage()).thenReturn("%USERNAME% has defeated %BOSS% with a new personal best time of %TIME% and a completion count of %COUNT%");
+
+        // init client mocks
+        when(client.getVarbitValue(Utils.ENABLE_PRECISE_TIMING)).thenReturn(1);
     }
 
     @Test
@@ -131,7 +135,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .content(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:00:56.500 and a completion count of 12")
+            .content(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56.50 and a completion count of 12")
             .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -162,7 +166,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 00:10:25.000 and a completion count of 10")
+                .content(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 10:25.00 and a completion count of 10")
                 .extra(new BossNotificationData("Crystalline Hunllef", 10, gameMessage, Duration.ofMinutes(10).plusSeconds(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -186,7 +190,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 00:06:30.000 and a completion count of 69")
+                .content(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 06:30.00 and a completion count of 69")
                 .extra(new BossNotificationData("Tempoross", 69, gameMessage, Duration.ofMinutes(6).plusSeconds(30), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -210,7 +214,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 00:25:00.000 and a completion count of 8")
+                .content(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 25:00.00 and a completion count of 8")
                 .extra(new BossNotificationData("Tombs of Amascut: Expert Mode", 8, gameMessage, Duration.ofMinutes(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -3,12 +3,14 @@ package dinkplugin.notifiers;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.BossNotificationData;
+import net.runelite.http.api.RuneLiteAPI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
 import java.time.Duration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.never;
@@ -45,16 +47,20 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // check notification
+        NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
+            .content(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 420")
+            .extra(new BossNotificationData("King Black Dragon", 420, gameMessage, null, null))
+            .playerName(PLAYER_NAME)
+            .type(NotificationType.KILL_COUNT)
+            .build();
+
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 420")
-                .extra(new BossNotificationData("King Black Dragon", 420, gameMessage, null, null))
-                .playerName(PLAYER_NAME)
-                .type(NotificationType.KILL_COUNT)
-                .build()
+            body
         );
+
+        assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
     }
 
     @Test
@@ -124,16 +130,20 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // check notification
+        NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
+            .content(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:00:56.500 and a completion count of 12")
+            .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
+            .playerName(PLAYER_NAME)
+            .type(NotificationType.KILL_COUNT)
+            .build();
+
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:00:56.500 and a completion count of 12")
-                .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
-                .playerName(PLAYER_NAME)
-                .type(NotificationType.KILL_COUNT)
-                .build()
+            body
         );
+
+        assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
     }
 
     @Test

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -30,6 +30,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         when(config.killCountNotifyBestTime()).thenReturn(true);
         when(config.killCountSendImage()).thenReturn(true);
         when(config.killCountMessage()).thenReturn("%USERNAME% has defeated %BOSS% with a completion count of %COUNT%");
+        when(config.killCountBestTimeMessage()).thenReturn("%USERNAME% has defeated %BOSS% with a new personal best time of %TIME% and a completion count of %COUNT%");
     }
 
     @Test
@@ -127,7 +128,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .content(PLAYER_NAME + " has defeated Zulrah with a completion count of 12")
+                .content(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:00:56.500 and a completion count of 12")
                 .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -128,7 +128,7 @@ class MatchersTest {
     @ParameterizedTest(name = "Kill count message should trigger on: {0}")
     @ArgumentsSource(KillCountProvider.class)
     void killCountRegexFindsMatch(String message, Pair<String, Integer> expected) {
-        assertEquals(expected, KillCountNotifier.parse(message).orElse(null));
+        assertEquals(expected, KillCountNotifier.parseBoss(message).orElse(null));
     }
 
     @ParameterizedTest(name = "Kill count message should not trigger on: {0}")
@@ -139,7 +139,7 @@ class MatchersTest {
         }
     )
     void killCountRegexDoesNotMatch(String message) {
-        assertFalse(KillCountNotifier.parse(message).isPresent());
+        assertFalse(KillCountNotifier.parseBoss(message).isPresent());
     }
 
     private static class KillCountProvider implements ArgumentsProvider {


### PR DESCRIPTION
* Allow kill count notification on personal best time (even if interval was not met)
* Utilize separate message template for best time notification
* Add latest fight duration to `extra` json data
