### PR TITLE
chore: bump mockito to 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Retry failed webhook messages with exponential backoff. (#94)
 - Minor: Add warning logs for improper runescape settings that impact notifiers. (#92)
 - Bugfix: Ensure boss name is included in boss slayer messages. (#88)
+- Dev: Bump mockito version to 4.11.0. (#107)
 - Dev: Add more plugin-hub search tags (#101)
 - Dev: Simplify notifier send image evaluation. (#102)
 - Dev: Bump mockito version to 4.10.0. (#95)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = junitVersion)
 
     // mocking and test injection used by runelite client
-    testImplementation(group = "org.mockito", name = "mockito-core", version = "4.10.0") // runelite uses 3.1.0
+    testImplementation(group = "org.mockito", name = "mockito-core", version = "4.11.0") // runelite uses 3.1.0
     testImplementation(group = "com.google.inject.extensions", name = "guice-testlib", version = "4.1.0") {
         exclude(group = "com.google.inject", module = "guice") // already provided by runelite client
     }


### PR DESCRIPTION
https://github.com/mockito/mockito/releases/tag/v4.11.0
