### PR TITLE
Release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.1.3
+
 - Minor: Add personal best time message to kill count notifier. (#106)
 - Minor: Add better descriptions for `Min Value` settings. (#100)
 - Minor: Add death notifier setting to disable kept item embeds. (#99)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.1.2"
+version = "1.1.3"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.1.3 contains a number of quality-of-life improvements and bug fixes. Most notably, kill count notifications can fire on new personal best times, loot from unsired can now trigger a notification (experimental), and webhook requests can be attempted multiple times with greater timeout (to work around transient network issues). 