### PR TITLE
chore(tests): add plugin mockito spy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Major: Use Discord rich embed format for webhooks. This is technically a possible breaking change for users that target non-Discord webhook servers; these users can revert to the old notification format by disabling the `Use Rich Embeds` setting in the `Advanced` section. (#110)
 - Minor: Add configurable player name ignore list for notifications. (#114)
 - Bugfix: Read unsired sprite dialog at end of game tick. This is still experimental for wider testing. (#112)
+- Dev: Allow full plugin mocking in unit tests. (#117)
 - Dev: Allow unit tests to post to an actual webhook server. (#110, #113)
 
 ## 1.1.3

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -120,8 +120,8 @@ public class SettingsManager {
             .forEach(ignoredNames::add);
         log.debug("Updated RSN Deny List to: {}", ignoredNames);
 
-        if (plugin != null)
-            plugin.resetNotifiers();
+        // clear any outdated notifier state
+        plugin.resetNotifiers();
     }
 
     private static boolean isCollectionLogInvalid(int varbitValue) {

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -68,7 +68,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         // fire widget event
         WidgetLoaded event = new WidgetLoaded();
         event.setGroupId(WidgetID.CLUE_SCROLL_REWARD_GROUP_ID);
-        notifier.onWidgetLoaded(event);
+        plugin.onWidgetLoaded(event);
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -101,7 +101,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         // fire widget event
         WidgetLoaded event = new WidgetLoaded();
         event.setGroupId(WidgetID.CLUE_SCROLL_REWARD_GROUP_ID);
-        notifier.onWidgetLoaded(event);
+        plugin.onWidgetLoaded(event);
 
         // ensure no notification was fired
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -129,7 +129,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         // fire widget event
         WidgetLoaded event = new WidgetLoaded();
         event.setGroupId(WidgetID.CLUE_SCROLL_REWARD_GROUP_ID);
-        notifier.onWidgetLoaded(event);
+        plugin.onWidgetLoaded(event);
 
         // ensure no notification was fired
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -10,11 +10,9 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.game.ItemManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
 import java.util.Collections;
 
@@ -31,9 +29,6 @@ class ClueNotifierTest extends MockedNotifierTest {
     private static final int TUNA_PRICE = 100;
 
     @Bind
-    @Mock
-    ItemManager itemManager;
-
     @InjectMocks
     ClueNotifier notifier;
 
@@ -50,8 +45,8 @@ class ClueNotifierTest extends MockedNotifierTest {
         when(config.clueNotifyMessage()).thenReturn("%USERNAME% has completed a %CLUE% clue, for a total of %COUNT%. They obtained: %LOOT%");
 
         // init item mocks
-        mockItem(itemManager, ItemID.RUBY, RUBY_PRICE, "Ruby");
-        mockItem(itemManager, ItemID.TUNA, TUNA_PRICE, "Tuna");
+        mockItem(ItemID.RUBY, RUBY_PRICE, "Ruby");
+        mockItem(ItemID.TUNA, TUNA_PRICE, "Tuna");
     }
 
     @Test

--- a/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.CollectionNotificationData;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 class CollectionNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     CollectionNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.CombatAchievementTier;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 class CombatTaskNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     CombatTaskNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -39,6 +40,7 @@ class DeathNotifierTest extends MockedNotifierTest {
     private static final int COAL_PRICE = 200;
     private static final int TUNA_PRICE = 100;
 
+    @Bind
     @InjectMocks
     DeathNotifier notifier;
 
@@ -72,7 +74,7 @@ class DeathNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyEmpty() {
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // verify notification
         verify(messageHandler).createMessage(
@@ -102,7 +104,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(inv.getItems()).thenReturn(items);
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // verify notification
         List<SerializedItemStack> kept = Arrays.asList(
@@ -142,7 +144,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(client.getPlayers()).thenReturn(Arrays.asList(mock(Player.class), mock(Player.class), other, mock(Player.class)));
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // verify notification
         verify(messageHandler).createMessage(
@@ -167,9 +169,9 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(localPlayer.getCombatLevel()).thenReturn(50);
 
         // fire events
-        notifier.onInteraction(new InteractingChanged(other, localPlayer));
-        notifier.onInteraction(new InteractingChanged(localPlayer, other));
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onInteractingChanged(new InteractingChanged(other, localPlayer));
+        plugin.onInteractingChanged(new InteractingChanged(localPlayer, other));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // verify notification
         verify(messageHandler).createMessage(
@@ -193,7 +195,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(client.getVarbitValue(Varbits.IN_WILDERNESS)).thenReturn(0);
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // verify non-PK notification
         verify(messageHandler).createMessage(
@@ -213,7 +215,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         Player other = mock(Player.class);
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(other));
+        plugin.onActorDeath(new ActorDeath(other));
 
         // ensure no notification occurred
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -226,7 +228,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(client.getVarpValue(WorldUtils.CASTLE_WARS_COUNTDOWN)).thenReturn(10);
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -238,7 +240,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(config.notifyDeath()).thenReturn(false);
 
         // fire event
-        notifier.onActorDeath(new ActorDeath(localPlayer));
+        plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -1,6 +1,5 @@
 package dinkplugin.notifiers;
 
-import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -17,11 +16,9 @@ import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.InteractingChanged;
-import net.runelite.client.game.ItemManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,10 +38,6 @@ class DeathNotifierTest extends MockedNotifierTest {
     private static final int OPAL_PRICE = 600;
     private static final int COAL_PRICE = 200;
     private static final int TUNA_PRICE = 100;
-
-    @Bind
-    @Mock
-    ItemManager itemManager;
 
     @InjectMocks
     DeathNotifier notifier;
@@ -69,11 +62,11 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(localPlayer.getWorldLocation()).thenReturn(location);
 
         // init item mocks
-        mockItem(itemManager, ItemID.RUBY, RUBY_PRICE, "Ruby");
-        mockItem(itemManager, ItemID.SHARK, SHARK_PRICE, "Shark");
-        mockItem(itemManager, ItemID.OPAL, OPAL_PRICE, "Opal");
-        mockItem(itemManager, ItemID.COAL, COAL_PRICE, "Coal");
-        mockItem(itemManager, ItemID.TUNA, TUNA_PRICE, "Tuna");
+        mockItem(ItemID.RUBY, RUBY_PRICE, "Ruby");
+        mockItem(ItemID.SHARK, SHARK_PRICE, "Shark");
+        mockItem(ItemID.OPAL, OPAL_PRICE, "Opal");
+        mockItem(ItemID.COAL, COAL_PRICE, "Coal");
+        mockItem(ItemID.TUNA, TUNA_PRICE, "Tuna");
     }
 
     @Test

--- a/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("MagicConstant")
 class DiaryNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     DiaryNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
@@ -53,7 +53,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger diary completion
         int id = Varbits.DIARY_DESERT_ELITE;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -79,7 +79,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger diary started
         int id = Varbits.DIARY_KARAMJA_HARD;
-        notifier.onVarbitChanged(event(id, 2));
+        plugin.onVarbitChanged(event(id, 2));
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -104,7 +104,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger diary started
         int id = Varbits.DIARY_KARAMJA_HARD;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -120,7 +120,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger varbit event
         int id = Varbits.DIARY_DESERT_ELITE;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -130,7 +130,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
     void testIgnoreUninitialized() {
         // trigger varbit event
         int id = Varbits.DIARY_DESERT_ELITE;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -146,7 +146,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger varbit event
         int id = Varbits.DIARY_FALADOR_EASY;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -165,7 +165,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
 
         // trigger diary completion
         int id = Varbits.DIARY_DESERT_ELITE;
-        notifier.onVarbitChanged(event(id, 1));
+        plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.util.TimeUtils;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 class KillCountNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     KillCountNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -1,6 +1,7 @@
 package dinkplugin.notifiers;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.LevelNotificationData;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 class LevelNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     LevelNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -37,15 +37,15 @@ class LevelNotifierTest extends MockedNotifierTest {
         when(config.levelNotifyMessage()).thenReturn("%USERNAME% has levelled %SKILL%");
 
         // init base level
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 0, 1, 1));
-        notifier.onStatChanged(new StatChanged(Skill.ATTACK, 14_000_000, 99, 99));
-        notifier.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 0, 1, 1));
+        plugin.onStatChanged(new StatChanged(Skill.ATTACK, 14_000_000, 99, 99));
+        plugin.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
     }
 
     @Test
     void testNotify() {
         // fire skill event
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
@@ -65,7 +65,7 @@ class LevelNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyVirtual() {
         // fire skill event
-        notifier.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
+        plugin.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
@@ -85,8 +85,8 @@ class LevelNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyTwo() {
         // fire skill events
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
-        notifier.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
+        plugin.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
@@ -106,9 +106,9 @@ class LevelNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyMany() {
         // fire skill events
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
-        notifier.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
-        notifier.onStatChanged(new StatChanged(Skill.HUNTER, 400, 5, 5));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
+        plugin.onStatChanged(new StatChanged(Skill.ATTACK, 15_000_000, 99, 100));
+        plugin.onStatChanged(new StatChanged(Skill.HUNTER, 400, 5, 5));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
@@ -128,7 +128,7 @@ class LevelNotifierTest extends MockedNotifierTest {
     @Test
     void testIgnoreInterval() {
         // fire skill event
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 100, 2, 2));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 100, 2, 2));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
@@ -143,7 +143,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         when(config.notifyLevel()).thenReturn(false);
 
         // fire skill event
-        notifier.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
+        plugin.onStatChanged(new StatChanged(Skill.AGILITY, 400, 5, 5));
 
         // let ticks pass
         IntStream.range(0, 4).forEach(i -> notifier.onTick());

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.LootNotificationData;
@@ -39,6 +40,7 @@ class LootNotifierTest extends MockedNotifierTest {
     private static final int TUNA_PRICE = 100;
     private static final String LOOTED_NAME = "Rasmus";
 
+    @Bind
     @InjectMocks
     LootNotifier notifier;
 
@@ -74,7 +76,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)));
-        notifier.onNpcLootReceived(event);
+        plugin.onNpcLootReceived(event);
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -96,7 +98,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)));
-        notifier.onNpcLootReceived(event);
+        plugin.onNpcLootReceived(event);
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -106,7 +108,7 @@ class LootNotifierTest extends MockedNotifierTest {
     void testNotifyPickpocket() {
         // fire event
         LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), RUBY_PRICE);
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -124,7 +126,7 @@ class LootNotifierTest extends MockedNotifierTest {
     void testIgnorePickpocket() {
         // fire event
         LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)), TUNA_PRICE);
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -138,7 +140,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
-        notifier.onPlayerLootReceived(event);
+        plugin.onPlayerLootReceived(event);
 
         // verify notification message
         verify(messageHandler).createMessage(
@@ -161,7 +163,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
-        notifier.onPlayerLootReceived(event);
+        plugin.onPlayerLootReceived(event);
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -182,7 +184,7 @@ class LootNotifierTest extends MockedNotifierTest {
             ),
             total
         );
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // verify notification message
         String loot = String.format("1 x Ruby (%d)\n1 x Opal (%d)", RUBY_PRICE, OPAL_PRICE);
@@ -214,7 +216,7 @@ class LootNotifierTest extends MockedNotifierTest {
             ),
             total
         );
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // verify notification message
         String loot = String.format("5 x Tuna (%d)", 5 * TUNA_PRICE);
@@ -245,7 +247,7 @@ class LootNotifierTest extends MockedNotifierTest {
         // fire event
         WidgetLoaded event = new WidgetLoaded();
         event.setGroupId(WidgetID.DIALOG_SPRITE_GROUP_ID);
-        notifier.onWidgetLoaded(event);
+        plugin.onWidgetLoaded(event);
 
         // verify notification message
         String source = "The Font of Consumption";
@@ -277,7 +279,7 @@ class LootNotifierTest extends MockedNotifierTest {
             ),
             total
         );
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -290,7 +292,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), RUBY_PRICE);
-        notifier.onLootReceived(event);
+        plugin.onLootReceived(event);
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -1,6 +1,5 @@
 package dinkplugin.notifiers;
 
-import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.LootNotificationData;
@@ -15,7 +14,6 @@ import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.plugins.loottracker.LootReceived;
 import net.runelite.client.util.QuantityFormatter;
@@ -23,7 +21,6 @@ import net.runelite.http.api.loottracker.LootRecordType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,10 +38,6 @@ class LootNotifierTest extends MockedNotifierTest {
     private static final int OPAL_PRICE = 600;
     private static final int TUNA_PRICE = 100;
     private static final String LOOTED_NAME = "Rasmus";
-
-    @Bind
-    @Mock
-    ItemManager itemManager;
 
     @InjectMocks
     LootNotifier notifier;
@@ -67,9 +60,9 @@ class LootNotifierTest extends MockedNotifierTest {
         when(localPlayer.getWorldLocation()).thenReturn(location);
 
         // init item mocks
-        mockItem(itemManager, ItemID.RUBY, RUBY_PRICE, "Ruby");
-        mockItem(itemManager, ItemID.OPAL, OPAL_PRICE, "Opal");
-        mockItem(itemManager, ItemID.TUNA, TUNA_PRICE, "Tuna");
+        mockItem(ItemID.RUBY, RUBY_PRICE, "Ruby");
+        mockItem(ItemID.OPAL, OPAL_PRICE, "Opal");
+        mockItem(ItemID.TUNA, TUNA_PRICE, "Tuna");
     }
 
     @Test
@@ -243,7 +236,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(spriteWidget.getItemId()).thenReturn(ItemID.ABYSSAL_WHIP);
         when(client.getWidget(WidgetInfo.DIALOG_SPRITE)).thenReturn(spriteWidget);
         final int whipPrice = 1_500_000;
-        mockItem(itemManager, ItemID.ABYSSAL_WHIP, whipPrice, "Abyssal Whip");
+        mockItem(ItemID.ABYSSAL_WHIP, whipPrice, "Abyssal Whip");
 
         Widget textWidget = mock(Widget.class);
         when(textWidget.getText()).thenReturn("The Font consumes the Unsired and returns you a reward.");

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -2,6 +2,7 @@ package dinkplugin.notifiers;
 
 import com.google.gson.Gson;
 import com.google.inject.testing.fieldbinder.Bind;
+import dinkplugin.DinkPlugin;
 import dinkplugin.DinkPluginConfig;
 import dinkplugin.MockedTestBase;
 import dinkplugin.SettingsManager;
@@ -15,6 +16,7 @@ import net.runelite.api.Player;
 import net.runelite.api.WorldType;
 import net.runelite.api.vars.AccountType;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.http.api.RuneLiteAPI;
@@ -62,7 +64,16 @@ abstract class MockedNotifierTest extends MockedTestBase {
     protected ScheduledExecutorService executor = new BlockingExecutor();
 
     @Bind
-    protected SettingsManager settingsManager = Mockito.spy(new SettingsManager(client, null, null, config));
+    protected ChatMessageManager chatManager = Mockito.mock(ChatMessageManager.class);
+
+    @Bind
+    protected ItemManager itemManager = Mockito.mock(ItemManager.class);
+
+    @Bind
+    protected DinkPlugin plugin = Mockito.spy(DinkPlugin.class);
+
+    @Bind
+    protected SettingsManager settingsManager = Mockito.spy(new SettingsManager(client, clientThread, plugin, config));
 
     @Bind
     protected DiscordMessageHandler messageHandler = Mockito.spy(new DiscordMessageHandler(gson, client, drawManager, httpClient, config, executor));
@@ -94,11 +105,11 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(config.embedFooterIcon()).thenReturn("https://github.com/pajlads/DinkPlugin/raw/master/icon.png");
     }
 
-    protected void mockItem(ItemManager manager, int id, int price, String name) {
-        when(manager.getItemPrice(id)).thenReturn(price);
+    protected void mockItem(int id, int price, String name) {
+        when(itemManager.getItemPrice(id)).thenReturn(price);
         ItemComposition item = mock(ItemComposition.class);
         when(item.getName()).thenReturn(name);
-        when(manager.getItemComposition(id)).thenReturn(item);
+        when(itemManager.getItemComposition(id)).thenReturn(item);
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 class PetNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     PetNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -44,7 +44,7 @@ class QuestNotifierTest extends MockedNotifierTest {
         when(questWidget.getText()).thenReturn("You have completed the Dragon Slayer quest!");
 
         // send event
-        notifier.onWidgetLoaded(event(QUEST_COMPLETED_GROUP_ID));
+        plugin.onWidgetLoaded(event(QUEST_COMPLETED_GROUP_ID));
 
         // verify notification
         verify(messageHandler).createMessage(
@@ -61,7 +61,7 @@ class QuestNotifierTest extends MockedNotifierTest {
     @Test
     void testIgnore() {
         // send unrelated event
-        notifier.onWidgetLoaded(event(-1));
+        plugin.onWidgetLoaded(event(-1));
 
         // verify no message
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -78,7 +78,7 @@ class QuestNotifierTest extends MockedNotifierTest {
         when(questWidget.getText()).thenReturn("You have completed the Dragon Slayer quest!");
 
         // send event
-        notifier.onWidgetLoaded(event(QUEST_COMPLETED_GROUP_ID));
+        plugin.onWidgetLoaded(event(QUEST_COMPLETED_GROUP_ID));
 
         // verify no message
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.QuestNotificationData;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 class QuestNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     QuestNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.SlayerNotificationData;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 class SlayerNotifierTest extends MockedNotifierTest {
 
+    @Bind
     @InjectMocks
     SlayerNotifier notifier;
 

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -62,7 +62,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         when(time.getText()).thenReturn(latest);
 
         // fire fake event
-        notifier.onWidgetLoaded(event());
+        plugin.onWidgetLoaded(event());
 
         // check notification message
         verify(messageHandler).createMessage(
@@ -86,7 +86,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         when(time.getText()).thenReturn(latest);
 
         // fire fake event
-        notifier.onWidgetLoaded(event());
+        plugin.onWidgetLoaded(event());
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -103,7 +103,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         when(time.getText()).thenReturn("1:15.30");
 
         // fire fake event
-        notifier.onWidgetLoaded(event());
+        plugin.onWidgetLoaded(event());
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
@@ -122,7 +122,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         when(time.getText()).thenReturn(latest);
 
         // fire fake event
-        notifier.onWidgetLoaded(event());
+        plugin.onWidgetLoaded(event());
 
         // check notification message
         verify(messageHandler).createMessage(
@@ -148,7 +148,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         when(time.getText()).thenReturn("1:15.30");
 
         // fire fake event
-        notifier.onWidgetLoaded(event());
+        plugin.onWidgetLoaded(event());
 
         // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -1,5 +1,6 @@
 package dinkplugin.notifiers;
 
+import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.SpeedrunNotificationData;
@@ -26,6 +27,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
 
     private static final String QUEST_NAME = "Cook's Assistant";
 
+    @Bind
     @InjectMocks
     SpeedrunNotifier notifier;
 


### PR DESCRIPTION
Allows for more comprehensive testing; events can be published to the plugin class (which will more realistically forward them to each notifier)