### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.2.0
+
 - Major: Use Discord rich embed format for webhooks. This is technically a possible breaking change for users that target non-Discord webhook servers; these users can revert to the old notification format by disabling the `Use Rich Embeds` setting in the `Advanced` section. (#110)
 - Minor: Add configurable player name ignore list for notifications. (#114)
 - Bugfix: Read unsired sprite dialog at end of game tick. This is still experimental for wider testing. (#112)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.1.3"
+version = "1.2.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.2.0 most notably now utilizes Discord's rich embed format for webhooks (with the ability to revert to the old format), and can be configured to skip notifications for certain player names.
