### PR TITLE
Added player url to the Discord embed author.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Made player names in Discord notifications link to a player profile page. This feature can be customized to different providers such as WiseOldMan & CrystalMathLabs in the Advanced menu. (#126)
 - Minor: Add setting to skip virtual level notifications. (#122)
 - Minor: Update the README to be less confusing to users. (#123)
 - Minor: Update embed icons for level up and slayer task notifications. (#119)

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -190,8 +190,8 @@ public interface DinkPluginConfig extends Config {
 
     @ConfigItem(
         keyName = "playerLookupService",
-        name = "Player lookup service",
-        description = "The service used to lookup a players name, in Discord embeds",
+        name = "Player Lookup Service",
+        description = "The service used to lookup a players account, to make their name clickable in Discord embeds",
         position = 1007,
         section = advancedSection
     )

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -2,6 +2,7 @@ package dinkplugin;
 
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.domain.CombatAchievementTier;
+import dinkplugin.domain.PlayerLookupService;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -185,6 +186,17 @@ public interface DinkPluginConfig extends Config {
     )
     default String ignoredNames() {
         return "";
+    }
+
+    @ConfigItem(
+        keyName = "playerLookupService",
+        name = "Player lookup service",
+        description = "The service used to lookup a players name, in Discord embeds",
+        position = 1007,
+        section = advancedSection
+    )
+    default PlayerLookupService playerLookupService() {
+        return PlayerLookupService.OSRS_HISCORE;
     }
 
     @ConfigItem(

--- a/src/main/java/dinkplugin/domain/PlayerLookupService.java
+++ b/src/main/java/dinkplugin/domain/PlayerLookupService.java
@@ -16,7 +16,7 @@ public enum PlayerLookupService {
     public String playerUrl(String playerName) {
         switch (this) {
             case OSRS_HISCORE:
-                return "https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=" + playerName;
+                return "https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=" + playerName;
             case WISEOLDMAN:
                 return "https://wiseoldman.net/players/" + playerName;
             case CRYSTAL_MATH_LABS:

--- a/src/main/java/dinkplugin/domain/PlayerLookupService.java
+++ b/src/main/java/dinkplugin/domain/PlayerLookupService.java
@@ -4,8 +4,8 @@ public enum PlayerLookupService {
     NONE("None"),
     OSRS_HISCORE("OSRS HiScore"),
     CRYSTAL_MATH_LABS("Crystal Math Labs"),
-    TEMPLEOSRS("Temple OSRS"),
-    WISEOLDMAN("Wise Old Man");
+    TEMPLE_OSRS("Temple OSRS"),
+    WISE_OLD_MAN("Wise Old Man");
 
     private final String name;
 
@@ -13,15 +13,15 @@ public enum PlayerLookupService {
         this.name = name;
     }
 
-    public String playerUrl(String playerName) {
+    public String getPlayerUrl(String playerName) {
         switch (this) {
             case OSRS_HISCORE:
                 return "https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=" + playerName;
-            case WISEOLDMAN:
+            case WISE_OLD_MAN:
                 return "https://wiseoldman.net/players/" + playerName;
             case CRYSTAL_MATH_LABS:
                 return "https://crystalmathlabs.com/track.php?player=" + playerName;
-            case TEMPLEOSRS:
+            case TEMPLE_OSRS:
                 return "https://templeosrs.com/player/overview.php?player=" + playerName;
             case NONE:
             default:

--- a/src/main/java/dinkplugin/domain/PlayerLookupService.java
+++ b/src/main/java/dinkplugin/domain/PlayerLookupService.java
@@ -1,0 +1,36 @@
+package dinkplugin.domain;
+
+public enum PlayerLookupService {
+    NONE("None"),
+    OSRS_HISCORE("OSRS HiScore"),
+    CRYSTAL_MATH_LABS("Crystal Math Labs"),
+    TEMPLEOSRS("Temple OSRS"),
+    WISEOLDMAN("Wise Old Man");
+
+    private final String name;
+
+    PlayerLookupService(String name) {
+        this.name = name;
+    }
+
+    public String playerUrl(String playerName) {
+        switch (this) {
+            case OSRS_HISCORE:
+                return "https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1=" + playerName;
+            case WISEOLDMAN:
+                return "https://wiseoldman.net/players/" + playerName;
+            case CRYSTAL_MATH_LABS:
+                return "https://crystalmathlabs.com/track.php?player=" + playerName;
+            case TEMPLEOSRS:
+                return "https://templeosrs.com/player/overview.php?player=" + playerName;
+            case NONE:
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/dinkplugin/message/Author.java
+++ b/src/main/java/dinkplugin/message/Author.java
@@ -26,4 +26,10 @@ public class Author {
     @Nullable
     @SerializedName("icon_url")
     String iconUrl;
+
+    /**
+     * Makes name a href and opens a browser with the url when clicked
+     */
+    @Nullable
+    String url;
 }

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -84,7 +84,7 @@ public class DiscordMessageHandler {
             mBody = mBody.withAccountType(client.getAccountType());
 
         if (config.discordRichEmbeds()) {
-            mBody = injectContent(mBody, sendImage, config.embedFooterText(), config.embedFooterIcon());
+            mBody = injectContent(mBody, sendImage, config);
         } else {
             mBody = mBody.withComputedDiscordContent(mBody.getText());
         }
@@ -162,9 +162,11 @@ public class DiscordMessageHandler {
         });
     }
 
-    private NotificationBody<?> injectContent(@NotNull NotificationBody<?> body, boolean screenshot, String footerText, String footerIcon) {
+    private static NotificationBody<?> injectContent(@NotNull NotificationBody<?> body, boolean screenshot, DinkPluginConfig config) {
         NotificationType type = body.getType();
         NotificationData extra = body.getExtra();
+        String footerText = config.embedFooterText();
+        String footerIcon = config.embedFooterIcon();
         PlayerLookupService playerLookupService = config.playerLookupService();
 
         Author author = Author.builder()

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -79,6 +79,9 @@ public class DiscordMessageHandler {
         if (mBody.getPlayerName() == null)
             mBody = mBody.withPlayerName(Utils.getPlayerName(client));
 
+        if (mBody.getPlayerUrl() == null)
+            mBody = mBody.withPlayerUrl(config.playerLookupService().playerUrl(mBody.getPlayerName()));
+
         if (mBody.getAccountType() == null)
             mBody = mBody.withAccountType(client.getAccountType());
 
@@ -167,6 +170,7 @@ public class DiscordMessageHandler {
 
         Author author = Author.builder()
             .name(body.getPlayerName())
+            .url(body.getPlayerUrl())
             .iconUrl(Utils.getChatBadge(body.getAccountType()))
             .build();
         Footer footer = StringUtils.isBlank(footerText) ? null : Footer.builder()

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -3,6 +3,7 @@ package dinkplugin.message;
 import com.google.gson.Gson;
 import dinkplugin.DinkPlugin;
 import dinkplugin.DinkPluginConfig;
+import dinkplugin.domain.PlayerLookupService;
 import dinkplugin.notifiers.data.NotificationData;
 import dinkplugin.util.Utils;
 import lombok.NonNull;
@@ -78,9 +79,6 @@ public class DiscordMessageHandler {
 
         if (mBody.getPlayerName() == null)
             mBody = mBody.withPlayerName(Utils.getPlayerName(client));
-
-        if (mBody.getPlayerUrl() == null)
-            mBody = mBody.withPlayerUrl(config.playerLookupService().playerUrl(mBody.getPlayerName()));
 
         if (mBody.getAccountType() == null)
             mBody = mBody.withAccountType(client.getAccountType());
@@ -164,13 +162,14 @@ public class DiscordMessageHandler {
         });
     }
 
-    private static NotificationBody<?> injectContent(@NotNull NotificationBody<?> body, boolean screenshot, String footerText, String footerIcon) {
+    private NotificationBody<?> injectContent(@NotNull NotificationBody<?> body, boolean screenshot, String footerText, String footerIcon) {
         NotificationType type = body.getType();
         NotificationData extra = body.getExtra();
+        PlayerLookupService playerLookupService = config.playerLookupService();
 
         Author author = Author.builder()
             .name(body.getPlayerName())
-            .url(body.getPlayerUrl())
+            .url(playerLookupService.getPlayerUrl(body.getPlayerName()))
             .iconUrl(Utils.getChatBadge(body.getAccountType()))
             .build();
         Footer footer = StringUtils.isBlank(footerText) ? null : Footer.builder()

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -26,6 +26,7 @@ public class NotificationBody<T extends NotificationData> {
     @NotNull
     NotificationType type;
     String playerName;
+    String playerUrl;
     AccountType accountType;
     @Nullable
     T extra;

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -26,8 +26,6 @@ public class NotificationBody<T extends NotificationData> {
     @NotNull
     NotificationType type;
     String playerName;
-    @Nullable
-    String playerUrl;
     AccountType accountType;
     @Nullable
     T extra;

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -26,6 +26,7 @@ public class NotificationBody<T extends NotificationData> {
     @NotNull
     NotificationType type;
     String playerName;
+    @Nullable
     String playerUrl;
     AccountType accountType;
     @Nullable

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -6,6 +6,7 @@ import dinkplugin.DinkPlugin;
 import dinkplugin.DinkPluginConfig;
 import dinkplugin.MockedTestBase;
 import dinkplugin.SettingsManager;
+import dinkplugin.domain.PlayerLookupService;
 import dinkplugin.message.DiscordMessageHandler;
 import dinkplugin.util.BlockingClientThread;
 import dinkplugin.util.BlockingExecutor;
@@ -103,6 +104,7 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(config.discordRichEmbeds()).thenReturn(!"false".equalsIgnoreCase(System.getenv("TEST_WEBHOOK_RICH")));
         when(config.embedFooterText()).thenReturn("Powered by Dink");
         when(config.embedFooterIcon()).thenReturn("https://github.com/pajlads/DinkPlugin/raw/master/icon.png");
+        when(config.playerLookupService()).thenReturn(PlayerLookupService.OSRS_HISCORE);
     }
 
     protected void mockItem(int id, int price, String name) {


### PR DESCRIPTION
Makes the author have a url that can be clicked. By default links to the osrs highscores, but other services are available.

Don't know where you want the config to be placed, but my suggestion would be to create separate "Discord" section? Since some configs are only meant for Discord and not for a generic webhook?
![image](https://user-images.githubusercontent.com/17124771/212473512-cab01cb3-f8e7-4add-9ba6-3350ffba1022.png)
