### PR TITLE
fix: avoid false settings warnings on world hops

### DIFF
--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -110,7 +110,7 @@ public class SettingsManager {
             if (client.getGameState() != GameState.LOGGED_IN)
                 return false;
 
-            if (queuedTicks.getAndIncrement() < 2)
+            if (queuedTicks.getAndIncrement() < 4)
                 return false;
 
             if (config.notifyCombatTask() && isRepeatPopupInvalid(client.getVarbitValue(CombatTaskNotifier.COMBAT_TASK_REPEAT_POPUP))) {


### PR DESCRIPTION
Delay varbit checks for a few ticks to avoid false `log.warn` calls on world hops

Note: with this approach, for the in-game message on settings changes, if one setting already is in the bad configuration and the user enables the second setting in a bad configuration, the plugin will send both warning messages upon the config change (but I'm personally fine with this)