### PR TITLE
chore: reduce diary initialization delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Reduce ticks to initialize diary notifier and improve logging for edge cases. (#129)
 - Minor: Made player names in Discord notifications link to a player profile page. This feature can be customized to different providers such as WiseOldMan & CrystalMathLabs in the Advanced menu. (#126)
 - Minor: Add setting to skip virtual level notifications. (#122)
 - Minor: Update the README to be less confusing to users. (#123)

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -79,14 +79,16 @@ public class DiaryNotifier extends BaseNotifier {
         } else if (value > previous) {
             diaryCompletionById.put(id, value);
 
-            if (!isComplete(id, value)) {
+            if (isComplete(id, value)) {
+                if (checkDifficulty(diary.getRight())) {
+                    handle(diary.getLeft(), diary.getRight());
+                } else {
+                    log.debug("Skipping {} {} diary due to low difficulty", diary.getRight(), diary.getLeft());
+                }
+            } else {
                 // Karamja special case
                 log.info("Skipping {} {} diary start (not a completion with value {})", diary.getRight(), diary.getLeft(), value);
-                return;
             }
-
-            if (checkDifficulty(diary.getRight()))
-                handle(diary.getLeft(), diary.getRight());
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -51,9 +51,9 @@ public class DiaryNotifier extends BaseNotifier {
 
             if (initDelayTicks <= 0)
                 this.initCompleted();
-        } else if (diaryCompletionById.isEmpty() && isEnabled()) {
+        } else if (diaryCompletionById.isEmpty() && super.isEnabled()) {
             // mark diary completions to be initialized later
-            this.initDelayTicks = 8;
+            this.initDelayTicks = 4;
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -81,7 +81,7 @@ public class DiaryNotifier extends BaseNotifier {
 
             if (!isComplete(id, value)) {
                 // Karamja special case
-                log.info("Skipping {} {} diary start (not a completion)", diary.getRight(), diary.getLeft());
+                log.info("Skipping {} {} diary start (not a completion with value {})", diary.getRight(), diary.getLeft(), value);
                 return;
             }
 

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -67,6 +67,7 @@ public class DiaryNotifier extends BaseNotifier {
         if (!super.isEnabled()) return;
         if (diaryCompletionById.isEmpty()) {
             if (client.getGameState() == GameState.LOGGED_IN && isComplete(id, event.getValue())) {
+                // this log only occurs in exceptional circumstances (i.e., completion within seconds of logging in or enabling the plugin)
                 log.info("Skipping {} {} diary completion that occurred before map initialization", diary.getRight(), diary.getLeft());
             }
             return;
@@ -75,9 +76,11 @@ public class DiaryNotifier extends BaseNotifier {
         int value = event.getValue();
         Integer previous = diaryCompletionById.get(id);
         if (previous == null) {
+            // this log should not occur, barring a jagex oddity
             log.warn("Resetting since {} {} diary was not initialized with a valid value; received new value of {}", diary.getRight(), diary.getLeft(), value);
             reset();
         } else if (value < previous) {
+            // this log should not occur, barring a jagex/runelite oddity
             log.info("Resetting since it appears {} {} diary has lost progress from {}; received new value of {}", diary.getRight(), diary.getLeft(), previous, value);
             reset();
         } else if (value > previous) {

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -123,12 +123,8 @@ public class DiaryNotifier extends BaseNotifier {
         for (Map.Entry<Integer, Integer> entry : diaryCompletionById.entrySet()) {
             int id = entry.getKey();
             int value = entry.getValue();
-            if (value <= 0) continue;
-
-            if (id != 3578 && id != 3599 && id != 3611) {
+            if (isComplete(id, value)) {
                 n++;
-            } else if (value > 1) {
-                n++; // Karamja special case
             }
         }
 

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -140,8 +140,12 @@ public class DiaryNotifier extends BaseNotifier {
     }
 
     private static boolean isComplete(int id, int value) {
-        // Karamja special case: 0 = not started, 1 = started, 2 = completed tasks
-        // otherwise: 0 = not started, 1 = completed
-        return id == 3578 || id == 3599 || id == 3611 ? value > 1 : value > 0;
+        if (id == 3578 || id == 3599 || id == 3611) {
+            // Karamja special case (except Elite): 0 = not started, 1 = started, 2 = completed tasks
+            return value > 1;
+        } else {
+            // otherwise: 0 = not started, 1 = completed
+            return value > 0;
+        }
     }
 }

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -74,7 +74,11 @@ public class DiaryNotifier extends BaseNotifier {
 
         int value = event.getValue();
         Integer previous = diaryCompletionById.get(id);
-        if (previous == null || value < previous) {
+        if (previous == null) {
+            log.warn("Resetting since {} {} diary was not initialized with a valid value; received new value of {}", diary.getRight(), diary.getLeft(), value);
+            reset();
+        } else if (value < previous) {
+            log.info("Resetting since it appears {} {} diary has lost progress from {}; received new value of {}", diary.getRight(), diary.getLeft(), previous, value);
             reset();
         } else if (value > previous) {
             diaryCompletionById.put(id, value);


### PR DESCRIPTION
Work towards https://github.com/pajlads/DinkPlugin/issues/124#issuecomment-1384333853

* Reduce init ticks from 8 to 4
* Allow diaryCompletionById initialization even if notifier is disabled
* Add logging for some edge cases
