### PR TITLE
fix: improve item price lookup for clue and loot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Minor: Add setting to skip virtual level notifications. (#122)
 - Minor: Update the README to be less confusing to users. (#123)
 - Minor: Update embed icons for level up and slayer task notifications. (#119)
+- Bugfix: Improve item price lookup for clue and loot notifiers so that coins are not worthless. (#131)
 
 ## 1.2.0
 

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -100,7 +100,7 @@ public class ClueNotifier extends BaseNotifier {
         clueItems.forEach((itemId, quantity) -> {
             if (lootMessage.length() > 0) lootMessage.append('\n');
 
-            int price = itemManager.getItemPrice(itemId);
+            int price = (int) ItemUtils.getPrice(itemManager, itemId);
             ItemComposition itemComposition = itemManager.getItemComposition(itemId);
             SerializedItemStack stack = new SerializedItemStack(itemId, quantity, price, itemComposition.getName());
 

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -7,7 +7,6 @@ import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
 import dinkplugin.notifiers.data.ClueNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
-import net.runelite.api.ItemComposition;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -99,11 +98,7 @@ public class ClueNotifier extends BaseNotifier {
 
         clueItems.forEach((itemId, quantity) -> {
             if (lootMessage.length() > 0) lootMessage.append('\n');
-
-            int price = (int) ItemUtils.getPrice(itemManager, itemId);
-            ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-            SerializedItemStack stack = new SerializedItemStack(itemId, quantity, price, itemComposition.getName());
-
+            SerializedItemStack stack = ItemUtils.stackFromItem(itemManager, itemId, quantity);
             totalPrice.addAndGet(stack.getTotalPrice());
             itemStacks.add(stack);
             lootMessage.append(getItemMessage(stack, embeds));

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -117,8 +117,8 @@ public class LootNotifier extends BaseNotifier {
         for (ItemStack item : reduced) {
             int itemId = item.getId();
             int quantity = item.getQuantity();
-            int price = itemManager.getItemPrice(itemId);
-            long totalPrice = (long) price * quantity;
+            long price = ItemUtils.getPrice(itemManager, itemId);
+            long totalPrice = price * quantity;
             ItemComposition itemComposition = itemManager.getItemComposition(itemId);
             if (totalPrice >= minValue) {
                 sendMessage = true;
@@ -126,7 +126,7 @@ public class LootNotifier extends BaseNotifier {
                 lootMessage.append(String.format("%s x %s (%s)", quantity, itemComposition.getName(), QuantityFormatter.quantityToStackSize(totalPrice)));
                 if (icons) embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(itemId)));
             }
-            serializedItems.add(new SerializedItemStack(itemId, quantity, price, itemComposition.getName()));
+            serializedItems.add(new SerializedItemStack(itemId, quantity, (int) price, itemComposition.getName()));
             totalStackValue += totalPrice;
         }
 

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -9,7 +9,6 @@ import dinkplugin.notifiers.data.LootNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.WorldUtils;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ItemComposition;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -115,18 +114,15 @@ public class LootNotifier extends BaseNotifier {
         boolean sendMessage = false;
 
         for (ItemStack item : reduced) {
-            int itemId = item.getId();
-            int quantity = item.getQuantity();
-            long price = ItemUtils.getPrice(itemManager, itemId);
-            long totalPrice = price * quantity;
-            ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+            SerializedItemStack stack = ItemUtils.stackFromItem(itemManager, item.getId(), item.getQuantity());
+            long totalPrice = stack.getTotalPrice();
             if (totalPrice >= minValue) {
                 sendMessage = true;
                 if (lootMessage.length() > 0) lootMessage.append("\n");
-                lootMessage.append(String.format("%s x %s (%s)", quantity, itemComposition.getName(), QuantityFormatter.quantityToStackSize(totalPrice)));
-                if (icons) embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(itemId)));
+                lootMessage.append(String.format("%d x %s (%s)", item.getQuantity(), stack.getName(), QuantityFormatter.quantityToStackSize(totalPrice)));
+                if (icons) embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(item.getId())));
             }
-            serializedItems.add(new SerializedItemStack(itemId, quantity, (int) price, itemComposition.getName()));
+            serializedItems.add(stack);
             totalStackValue += totalPrice;
         }
 

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -63,10 +63,12 @@ public class ItemUtils {
         return getPrice(itemManager, itemId, null);
     }
 
-    private int getPrice(@NotNull ItemManager manager, int itemId, @Nullable ItemComposition item) {
-        int price = manager.getItemPrice(itemId);
+    private int getPrice(@NotNull ItemManager itemManager, int itemId, @Nullable ItemComposition item) {
+        // GE price sourced from wiki with anti-manipulation massaging by runelite
+        int price = itemManager.getItemPrice(itemId);
         if (price <= 0) {
-            ItemComposition ic = item != null ? item : manager.getItemComposition(itemId);
+            // fallback: store price
+            ItemComposition ic = item != null ? item : itemManager.getItemComposition(itemId);
             price = ic.getPrice();
         }
         return price;

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -13,6 +13,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.util.QuantityFormatter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,9 +63,17 @@ public class ItemUtils {
         return NEVER_KEPT_ITEMS.contains(itemId);
     }
 
-    public long getPrice(ItemManager itemManager, int itemId) {
-        int price = itemManager.getItemPrice(itemId);
-        return price > 0 ? price : itemManager.getItemComposition(itemId).getPrice();
+    public long getPrice(@NotNull ItemManager itemManager, int itemId) {
+        return getPrice(itemManager, itemId, null);
+    }
+
+    private int getPrice(@NotNull ItemManager manager, int itemId, @Nullable ItemComposition item) {
+        int price = manager.getItemPrice(itemId);
+        if (price <= 0) {
+            ItemComposition ic = item != null ? item : manager.getItemComposition(itemId);
+            price = ic.getPrice();
+        }
+        return price;
     }
 
     public Collection<Item> getItems(Client client) {
@@ -98,8 +107,8 @@ public class ItemUtils {
     }
 
     public SerializedItemStack stackFromItem(ItemManager itemManager, int id, int quantity) {
-        int price = (int) getPrice(itemManager, id);
         ItemComposition composition = itemManager.getItemComposition(id);
+        int price = getPrice(itemManager, id, composition);
         return new SerializedItemStack(id, quantity, price, composition.getName());
     }
 

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -28,12 +28,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.runelite.api.ItemID.*;
-import static net.runelite.api.ItemID.TWISTED_BRONZE_TROPHY;
-import static net.runelite.api.ItemID.TWISTED_DRAGON_TROPHY;
-import static net.runelite.api.ItemID.TWISTED_IRON_TROPHY;
-import static net.runelite.api.ItemID.TWISTED_MITHRIL_TROPHY;
-import static net.runelite.api.ItemID.TWISTED_RUNE_TROPHY;
-import static net.runelite.api.ItemID.TWISTED_STEEL_TROPHY;
 
 @UtilityClass
 public class ItemUtils {

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -94,9 +94,11 @@ public class ItemUtils {
     }
 
     public SerializedItemStack stackFromItem(ItemManager itemManager, Item item) {
-        int id = item.getId();
-        int quantity = item.getQuantity();
-        int price = itemManager.getItemPrice(id);
+        return stackFromItem(itemManager, item.getId(), item.getQuantity());
+    }
+
+    public SerializedItemStack stackFromItem(ItemManager itemManager, int id, int quantity) {
+        int price = (int) getPrice(itemManager, id);
         ItemComposition composition = itemManager.getItemComposition(id);
         return new SerializedItemStack(id, quantity, price, composition.getName());
     }


### PR DESCRIPTION
Resolves an issue where coins could be thought to have 0 value instead of 1gp each (which @Supinic recently experienced when the clue notifier skipped a notification for [these items](https://i.imgur.com/0fzeOVz.png), given a value threshold of 20k)