### PR TITLE
fix: improve player killer identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Add setting to skip virtual level notifications. (#122)
 - Minor: Update the README to be less confusing to users. (#123)
 - Minor: Update embed icons for level up and slayer task notifications. (#119)
+- Bugfix: Improve PKer identification in death notifier using characteristics such as clan. (#137)
 - Bugfix: Improve item price lookup for clue and loot notifiers so that coins are not worthless. (#131)
 
 ## 1.2.0


### PR DESCRIPTION
`DeathNotifier#identifyPker` should prioritize alive, non-clan members, non-friends, non-FC, similar level, skulled players

Work towards addressing edge cases referenced in https://github.com/pajlads/DinkPlugin/issues/116#issuecomment-1378050411
