### PR TITLE
fix: assume singular loot quantity from unsired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Report correct item quantity from unsired loot. (#147)
+
 ## 1.2.2
 
 - Bugfix: Fix embed author url breaking notifications when the player has a space in their name. (#143)

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -87,7 +87,7 @@ public class LootNotifier extends BaseNotifier {
                     if (hasItem(spriteWidget)) {
                         ItemStack item = new ItemStack(
                             spriteWidget.getItemId(),
-                            Math.max(spriteWidget.getItemQuantity(), 1),
+                            1,
                             client.getLocalPlayer().getLocalLocation()
                         );
                         this.handleNotify(Collections.singletonList(item), "The Font of Consumption");


### PR DESCRIPTION
Fixes #146 

We used the theoretically correct method to get the item quantity but it reports erroneous values, so we hardcode 1 instead given the actual loot [table](https://oldschool.runescape.wiki/w/Unsired#Rewards).
