### PR TITLE
feat: parse pet name from clan message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Include pet name in rich embeds and notification metadata. (#149)
+- Minor: Include pet name in rich embeds and notification metadata if the user has clan notifications on. (#149)
 - Bugfix: Report correct item quantity from unsired loot. (#147)
 
 ## 1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Include pet name in rich embeds and notification metadata. (#149)
 - Bugfix: Report correct item quantity from unsired loot. (#147)
 
 ## 1.2.2

--- a/README.md
+++ b/README.md
@@ -352,9 +352,14 @@ The examples below omit `embeds` and `playerName` keys because they are always t
 ```json5
 {
   "content": "%USERNAME% has a funny feeling they are being followed",
+  "extra": {
+    "petName": "Ikkle hydra"
+  },
   "type": "PET"
 }
 ```
+
+Note: `petName` is only included if the game sent it to your chat channel.
 </details>
 
 ### Speedrunning:

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The examples below omit `embeds` and `playerName` keys because they are always t
 }
 ```
 
-Note: `petName` is only included if the game sent it to your chat channel.
+Note: `petName` is only included if the game sent it to your chat via clan notifications.
 </details>
 
 ### Speedrunning:

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -138,6 +138,7 @@ public class DinkPlugin extends Plugin {
             clueNotifier.onChatMessage(chatMessage);
             killCountNotifier.onGameMessage(chatMessage);
             combatTaskNotifier.onGameMessage(chatMessage);
+            return;
         }
 
         if (Utils.CLAN_NOTIFICATIONS.contains(msgType)) {

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -82,6 +82,7 @@ public class DinkPlugin extends Plugin {
     }
 
     void resetNotifiers() {
+        petNotifier.reset();
         clueNotifier.reset();
         diaryNotifier.reset();
         levelNotifier.reset();
@@ -117,6 +118,7 @@ public class DinkPlugin extends Plugin {
 
     @Subscribe
     public void onGameTick(GameTick event) {
+        petNotifier.onTick();
         clueNotifier.onTick();
         slayerNotifier.onTick();
         levelNotifier.onTick();
@@ -138,7 +140,8 @@ public class DinkPlugin extends Plugin {
             combatTaskNotifier.onGameMessage(chatMessage);
         }
 
-        if (msgType == ChatMessageType.FRIENDSCHATNOTIFICATION) {
+        if (Utils.CLAN_NOTIFICATIONS.contains(msgType)) {
+            petNotifier.onClanNotification(chatMessage);
             killCountNotifier.onFriendsChatNotification(chatMessage);
         }
     }

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -128,22 +128,30 @@ public class DinkPlugin extends Plugin {
 
     @Subscribe
     public void onChatMessage(ChatMessage message) {
-        ChatMessageType msgType = message.getType();
         String chatMessage = Text.removeTags(message.getMessage().replace("<br>", "\n")).replace('\u00A0', ' ').trim();
+        switch (message.getType()) {
+            case GAMEMESSAGE:
+                collectionNotifier.onChatMessage(chatMessage);
+                petNotifier.onChatMessage(chatMessage);
+                slayerNotifier.onChatMessage(chatMessage);
+                clueNotifier.onChatMessage(chatMessage);
+                killCountNotifier.onGameMessage(chatMessage);
+                combatTaskNotifier.onGameMessage(chatMessage);
+                break;
 
-        if (msgType == ChatMessageType.GAMEMESSAGE) {
-            collectionNotifier.onChatMessage(chatMessage);
-            petNotifier.onChatMessage(chatMessage);
-            slayerNotifier.onChatMessage(chatMessage);
-            clueNotifier.onChatMessage(chatMessage);
-            killCountNotifier.onGameMessage(chatMessage);
-            combatTaskNotifier.onGameMessage(chatMessage);
-            return;
-        }
+            case FRIENDSCHATNOTIFICATION:
+                killCountNotifier.onFriendsChatNotification(chatMessage);
+                // intentional fallthrough to clan notifications
 
-        if (Utils.CLAN_NOTIFICATIONS.contains(msgType)) {
-            petNotifier.onClanNotification(chatMessage);
-            killCountNotifier.onFriendsChatNotification(chatMessage);
+            case CLAN_MESSAGE:
+            case CLAN_GUEST_MESSAGE:
+            case CLAN_GIM_MESSAGE:
+                petNotifier.onClanNotification(chatMessage);
+                break;
+
+            default:
+                // do nothing
+                break;
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -2,14 +2,29 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.notifiers.data.PetNotificationData;
+import dinkplugin.util.ItemSearcher;
+import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Singleton
 public class PetNotifier extends BaseNotifier {
     @VisibleForTesting
     static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you|feel something weird sneaking).*");
+    private static final Pattern CLAN_REGEX = Pattern.compile("\\b(?<user>[\\w\\s]+) (?:has a funny feeling like .+ followed|feels something weird sneaking into .+ backpack): (?<pet>.+) at\\s");
+
+    @Inject
+    private ItemSearcher itemSearcher;
+
+    private String petName = null;
 
     @Override
     public boolean isEnabled() {
@@ -22,18 +37,52 @@ public class PetNotifier extends BaseNotifier {
     }
 
     public void onChatMessage(String chatMessage) {
-        if (isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
-            this.handleNotify();
+        if (petName == null && isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
+            this.petName = "";
         }
+    }
+
+    public void onClanNotification(String message) {
+        if (petName != null) {
+            Matcher matcher = CLAN_REGEX.matcher(message);
+            if (matcher.find()) {
+                String user = matcher.group("user").trim();
+                if (user.equals(Utils.getPlayerName(client))) {
+                    this.petName = matcher.group("pet");
+                }
+            }
+        }
+    }
+
+    public void onTick() {
+        if (petName != null)
+            this.handleNotify();
+    }
+
+    public void reset() {
+        this.petName = null;
     }
 
     private void handleNotify() {
         String notifyMessage = config.petNotifyMessage()
             .replace("%USERNAME%", Utils.getPlayerName(client));
 
+        String thumbnail = Optional.ofNullable(petName)
+            .filter(s -> !s.isEmpty())
+            .map(Utils::ucFirst)
+            .map(itemSearcher::findItemId)
+            .map(ItemUtils::getItemImageUrl)
+            .orElse(null);
+
+        PetNotificationData extra = StringUtils.isNotEmpty(petName) ? new PetNotificationData(petName) : null;
+
         createMessage(config.petSendImage(), NotificationBody.builder()
+            .extra(extra)
             .text(notifyMessage)
+            .thumbnailUrl(thumbnail)
             .type(NotificationType.PET)
             .build());
+
+        reset();
     }
 }

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -41,7 +41,7 @@ public class PetNotifier extends BaseNotifier {
     }
 
     public void onChatMessage(String chatMessage) {
-        if (petName == null && isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
+        if (isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
             // Prime the notifier to trigger next tick
             this.petName = PRIMED_NAME;
         }

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -19,7 +19,9 @@ import java.util.regex.Pattern;
 public class PetNotifier extends BaseNotifier {
     @VisibleForTesting
     static final Pattern PET_REGEX = Pattern.compile("You (?:have a funny feeling like you|feel something weird sneaking).*");
-    private static final Pattern CLAN_REGEX = Pattern.compile("\\b(?<user>[\\w\\s]+) (?:has a funny feeling like .+ followed|feels something weird sneaking into .+ backpack): (?<pet>.+) at\\s");
+
+    @VisibleForTesting
+    static final Pattern CLAN_REGEX = Pattern.compile("\\b(?<user>[\\w\\s]+) (?:has a funny feeling like .+ followed|feels something weird sneaking into .+ backpack): (?<pet>.+) at\\s");
 
     @Inject
     private ItemSearcher itemSearcher;

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -44,13 +44,15 @@ public class PetNotifier extends BaseNotifier {
     }
 
     public void onClanNotification(String message) {
-        if (petName != null) {
-            Matcher matcher = CLAN_REGEX.matcher(message);
-            if (matcher.find()) {
-                String user = matcher.group("user").trim();
-                if (user.equals(Utils.getPlayerName(client))) {
-                    this.petName = matcher.group("pet");
-                }
+        // Clan message can only come after the normal pet message
+        if (petName == null)
+            return;
+
+        Matcher matcher = CLAN_REGEX.matcher(message);
+        if (matcher.find()) {
+            String user = matcher.group("user").trim();
+            if (user.equals(Utils.getPlayerName(client))) {
+                this.petName = matcher.group("pet");
             }
         }
     }
@@ -75,7 +77,7 @@ public class PetNotifier extends BaseNotifier {
             .map(ItemUtils::getItemImageUrl)
             .orElse(null);
 
-        PetNotificationData extra = StringUtils.isNotEmpty(petName) ? new PetNotificationData(petName) : null;
+        PetNotificationData extra = new PetNotificationData(StringUtils.defaultIfEmpty(petName, null));
 
         createMessage(config.petSendImage(), NotificationBody.builder()
             .extra(extra)

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -48,9 +48,10 @@ public class PetNotifier extends BaseNotifier {
     }
 
     public void onClanNotification(String message) {
-        // Clan message can only come after the normal pet message
-        if (!PRIMED_NAME.equals(petName))
+        if (!PRIMED_NAME.equals(petName)) {
+            // We have not received the normal message about a pet drop, so this clan message cannot be relevant to us
             return;
+        }
 
         Matcher matcher = CLAN_REGEX.matcher(message);
         if (matcher.find()) {

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -23,6 +23,8 @@ public class PetNotifier extends BaseNotifier {
     @VisibleForTesting
     static final Pattern CLAN_REGEX = Pattern.compile("\\b(?<user>[\\w\\s]+) (?:has a funny feeling like .+ followed|feels something weird sneaking into .+ backpack): (?<pet>.+) at\\s");
 
+    private static final String PRIMED_NAME = "";
+
     @Inject
     private ItemSearcher itemSearcher;
 
@@ -41,13 +43,13 @@ public class PetNotifier extends BaseNotifier {
     public void onChatMessage(String chatMessage) {
         if (petName == null && isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
             // Prime the notifier to trigger next tick
-            this.petName = "";
+            this.petName = PRIMED_NAME;
         }
     }
 
     public void onClanNotification(String message) {
         // Clan message can only come after the normal pet message
-        if (petName == null)
+        if (!PRIMED_NAME.equals(petName))
             return;
 
         Matcher matcher = CLAN_REGEX.matcher(message);

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -38,6 +38,7 @@ public class PetNotifier extends BaseNotifier {
 
     public void onChatMessage(String chatMessage) {
         if (petName == null && isEnabled() && PET_REGEX.matcher(chatMessage).matches()) {
+            // Prime the notifier to trigger next tick
             this.petName = "";
         }
     }

--- a/src/main/java/dinkplugin/notifiers/data/PetNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/PetNotificationData.java
@@ -1,0 +1,24 @@
+package dinkplugin.notifiers.data;
+
+import dinkplugin.message.Field;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import java.util.Collections;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class PetNotificationData extends NotificationData {
+    String petName;
+
+    @Override
+    public List<Field> getFields() {
+        if (petName == null || petName.isEmpty())
+            return super.getFields();
+
+        return Collections.singletonList(
+            new Field("Name", "```\n" + petName + "\n```")
+        );
+    }
+}

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -3,7 +3,6 @@ package dinkplugin.util;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import lombok.experimental.UtilityClass;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.vars.AccountType;
 import net.runelite.api.widgets.Widget;
@@ -25,9 +24,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -35,15 +31,6 @@ import java.util.function.Function;
 public class Utils {
 
     public static final String WIKI_IMG_BASE_URL = "https://oldschool.runescape.wiki/images/";
-
-    public final Set<ChatMessageType> CLAN_NOTIFICATIONS = Collections.unmodifiableSet(
-        EnumSet.of(
-            ChatMessageType.FRIENDSCHATNOTIFICATION,
-            ChatMessageType.CLAN_MESSAGE,
-            ChatMessageType.CLAN_GUEST_MESSAGE,
-            ChatMessageType.CLAN_GIM_MESSAGE
-        )
-    );
 
     public final Color PINK = ColorUtil.fromHex("#f40098"); // analogous to RED in CIELCh_uv color space
     public final Color RED = ColorUtil.fromHex("#ca2a2d"); // red used in pajaW

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -3,6 +3,7 @@ package dinkplugin.util;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import lombok.experimental.UtilityClass;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.vars.AccountType;
 import net.runelite.api.widgets.Widget;
@@ -24,6 +25,9 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -32,8 +36,28 @@ public class Utils {
 
     public static final String WIKI_IMG_BASE_URL = "https://oldschool.runescape.wiki/images/";
 
+    public final Set<ChatMessageType> CLAN_NOTIFICATIONS = Collections.unmodifiableSet(
+        EnumSet.of(
+            ChatMessageType.FRIENDSCHATNOTIFICATION,
+            ChatMessageType.CLAN_MESSAGE,
+            ChatMessageType.CLAN_GUEST_MESSAGE,
+            ChatMessageType.CLAN_GIM_MESSAGE
+        )
+    );
+
     public final Color PINK = ColorUtil.fromHex("#f40098"); // analogous to RED in CIELCh_uv color space
     public final Color RED = ColorUtil.fromHex("#ca2a2d"); // red used in pajaW
+
+    /**
+     * Converts text into "upper case first" form, as is used by OSRS for item names.
+     *
+     * @param text the string to be transformed
+     * @return the text with only the first character capitalized
+     */
+    public String ucFirst(@NotNull String text) {
+        if (text.length() < 2) return text.toUpperCase();
+        return Character.toUpperCase(text.charAt(0)) + text.substring(1).toLowerCase();
+    }
 
     public boolean isSettingsOpen(@NotNull Client client) {
         Widget widget = client.getWidget(WidgetInfo.SETTINGS_INIT);

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -100,31 +100,6 @@ class MatchersTest {
         }
     }
 
-    @ParameterizedTest(name = "Pet message should trigger {0}")
-    @ValueSource(
-        strings = {
-            "You have a funny feeling like you're being followed.",
-            "You have a funny feeling like you would have been followed...",
-            "You feel something weird sneaking into your backpack."
-        }
-    )
-    void petRegexFindsMatch(String message) {
-        Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
-        assertTrue(matcher.find());
-    }
-
-    @ParameterizedTest(name = "Pet message should not trigger {0}")
-    @ValueSource(
-        strings = {
-            "Forsen: forsen",
-            "You feel like you forgot to turn the stove off"
-        }
-    )
-    void petRegexDoesNotMatch(String message) {
-        Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
-        assertFalse(matcher.find());
-    }
-
     @ParameterizedTest(name = "Kill count message should trigger on: {0}")
     @ArgumentsSource(KillCountProvider.class)
     void killCountRegexFindsMatch(String message, Pair<String, Integer> expected) {

--- a/src/test/java/dinkplugin/notifiers/PetMatcherTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetMatcherTest.java
@@ -1,0 +1,77 @@
+package dinkplugin.notifiers;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PetMatcherTest {
+
+    @ParameterizedTest(name = "Pet message should trigger {0}")
+    @ValueSource(
+        strings = {
+            "You have a funny feeling like you're being followed.",
+            "You have a funny feeling like you would have been followed...",
+            "You feel something weird sneaking into your backpack."
+        }
+    )
+    void petRegexFindsMatch(String message) {
+        Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
+        assertTrue(matcher.find());
+    }
+
+    @ParameterizedTest(name = "Pet message should not trigger {0}")
+    @ValueSource(
+        strings = {
+            "Forsen: forsen",
+            "You feel like you forgot to turn the stove off"
+        }
+    )
+    void petRegexDoesNotMatch(String message) {
+        Matcher matcher = PetNotifier.PET_REGEX.matcher(message);
+        assertFalse(matcher.find());
+    }
+
+    @ParameterizedTest(name = "Pet name should be parsed from: {0}")
+    @ArgumentsSource(ClanPetProvider.class)
+    void petNameMatches(String message, String user, String pet) {
+        Matcher matcher = PetNotifier.CLAN_REGEX.matcher(message);
+        assertTrue(matcher.find());
+        assertEquals(user, matcher.group("user"));
+        assertEquals(pet, matcher.group("pet"));
+    }
+
+    @ParameterizedTest(name = "Pet name should be not parsed from {0}")
+    @ValueSource(
+        strings = {
+            "Forsen: forsen",
+            "You feel like you forgot to turn the stove off"
+        }
+    )
+    void petNameDoesNotMatch(String message) {
+        Matcher matcher = PetNotifier.CLAN_REGEX.matcher(message);
+        assertFalse(matcher.find());
+    }
+
+    private static class ClanPetProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("[Log Dog LLC] Clipper has a funny feeling like he's being followed: Little nightmare at 2,678 killcount.", "Clipper", "Little nightmare"),
+                Arguments.of("[Muu] Majin Muu has a funny feeling like she's being followed: Herbi at 3,054 harvest count.", "Majin Muu", "Herbi"),
+                Arguments.of("[Dankermen] pajdank has a funny feeling like he's being followed: Rocky at 5,850,317 XP.", "pajdank", "Rocky"),
+                Arguments.of("[Outer Void] Dash Inc feels something weird sneaking into his backpack: Heron at 8,426,283 XP.", "Dash Inc", "Heron")
+            );
+        }
+    }
+
+}

--- a/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
@@ -50,6 +50,7 @@ class PetNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
+                .extra(new PetNotificationData(null))
                 .text(PLAYER_NAME + " got a pet")
                 .type(NotificationType.PET)
                 .build()
@@ -102,6 +103,7 @@ class PetNotifierTest extends MockedNotifierTest {
             "https://example.com",
             false,
             NotificationBody.builder()
+                .extra(new PetNotificationData(null))
                 .text(PLAYER_NAME + " got a pet")
                 .type(NotificationType.PET)
                 .build()
@@ -146,6 +148,7 @@ class PetNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
+                .extra(new PetNotificationData(null))
                 .text(PLAYER_NAME + " got a pet")
                 .type(NotificationType.PET)
                 .build()


### PR DESCRIPTION
Include pet name in extra notification data when parseable from accompanying clan notification message.

Related: #20

![image](https://user-images.githubusercontent.com/8106344/215376789-c151e6ea-0272-43ea-953d-a57464ebfdae.png)
