### PR TITLE
fix: improve thread safety of notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Minor: Add warning when in-game kill count chat spam filter is enabled. (#154)
 - Minor: Include pet name in webhooks when available in chat via clan, collection log, or untradeable drop notifications. (#149, #153)
 - Bugfix: Report correct item quantity from unsired loot. (#147)
+- Dev: Improve thread-safety of notifiers. (#156)
 
 ## 1.2.2
 

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -55,7 +55,7 @@ public class DiaryNotifier extends BaseNotifier {
             if (ticks == 1) {
                 this.initCompleted();
             }
-        } else if (diaryCompletionById.isEmpty() && super.isEnabled()) {
+        } else if (diaryCompletionById.size() < DIARIES.size() && super.isEnabled()) {
             // mark diary completions to be initialized later
             this.initDelayTicks.set(4);
         }

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -143,7 +143,7 @@ public class DiaryNotifier extends BaseNotifier {
                 diaryCompletionById.put(id, value);
             }
         }
-        log.debug("Finished initializing current diary completions: {} out of {}", getTotalCompleted(), diaryCompletionById.size());
+        log.info("Finished initializing current diary completions: {} out of {}", getTotalCompleted(), diaryCompletionById.size());
     }
 
     private static boolean isComplete(int id, int value) {

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -1,10 +1,10 @@
 package dinkplugin.notifiers;
 
-import dinkplugin.util.Utils;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.DiaryNotificationData;
+import dinkplugin.util.Utils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
@@ -13,9 +13,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static dinkplugin.domain.AchievementDiary.DIARIES;
@@ -23,7 +22,7 @@ import static dinkplugin.domain.AchievementDiary.DIARIES;
 @Slf4j
 @Singleton
 public class DiaryNotifier extends BaseNotifier {
-    private final Map<Integer, Integer> diaryCompletionById = Collections.synchronizedMap(new HashMap<>());
+    private final Map<Integer, Integer> diaryCompletionById = new ConcurrentHashMap<>();
     private final AtomicInteger initDelayTicks = new AtomicInteger();
 
     @Override

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -38,7 +38,7 @@ public class KillCountNotifier extends BaseNotifier {
     private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>\\d+)\\b");
     private static final Pattern TIME_REGEX = Pattern.compile("(?:Duration|time|Subdued in):? (?<time>[\\d:]+(.\\d+)?)\\.?", Pattern.CASE_INSENSITIVE);
 
-    private BossNotificationData data;
+    private volatile BossNotificationData data = null;
 
     @Override
     public boolean isEnabled() {

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -2,8 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
-import dinkplugin.util.Utils;
 import dinkplugin.notifiers.data.LevelNotificationData;
+import dinkplugin.util.Utils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
@@ -13,19 +13,18 @@ import net.runelite.api.events.StatChanged;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Singleton
 public class LevelNotifier extends BaseNotifier {
-
-    private final List<String> levelledSkills = Collections.synchronizedList(new ArrayList<>());
-    private final Map<String, Integer> currentLevels = Collections.synchronizedMap(new HashMap<>());
+    private final List<String> levelledSkills = new CopyOnWriteArrayList<>();
+    private final Map<String, Integer> currentLevels = new ConcurrentHashMap<>();
     private final AtomicInteger ticksWaited = new AtomicInteger();
     private volatile boolean sendMessage = false;
 

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -47,7 +47,7 @@ public class PetNotifier extends BaseNotifier {
     private ItemSearcher itemSearcher;
 
     @Setter(AccessLevel.PRIVATE)
-    private String petName = null;
+    private volatile String petName = null;
 
     @Override
     public boolean isEnabled() {


### PR DESCRIPTION
Since the internal state of notifiers can be modified by multiple threads (e.g., swing thread can trigger `reset` while client thread is the main user of the internal state), this PR makes all usage of saved state in notifiers thread-safe.

*May* be related to #93
