### PR TITLE
feat: require argument for config export to include urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Major: Add Barbarian Assault high level gambling notifications. (#150)
-- Minor: Add plugin config export and import chat commands. (#155)
+- Minor: Add plugin config export and import chat commands. (#155, #160)
 - Minor: Make time units of advanced settings more obvious in the user interface. (#158)
 - Minor: Clean up setting tooltips that stretched too wide, making them difficult to read. (#151)
 - Minor: Add warning when in-game kill count chat spam filter is enabled. (#154)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Some notifiers require in-game settings to be configured to send chat messages u
 Dink allows you to export your current plugin configuration to the clipboard via the `::dinkexport` chat command.
 
 This export includes settings across all of the notifiers. If you want to include webhook URLs in the export, run the `::dinkexport all` chat command.
+Alternatively, if you *only* want to export the webhook URLs, run the `::dinkexport webhooks` chat command.
 
 You can share this produced JSON to friends who want to send similarly configured messages.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Some notifiers require in-game settings to be configured to send chat messages u
 
 ## Chat Commands
 
-### Export Current Configuration via `::DinkExport`
+### Export Current Configuration via `::dinkexport`
 
 Dink allows you to export your current plugin configuration to the clipboard via the `::dinkexport` chat command.
 
@@ -56,8 +56,8 @@ If you want to include webhook URLs in the export, run the `::dinkexport all` ch
 Alternatively, if you *only* want to export the webhook URLs, run the `::dinkexport webhooks` chat command.
 
 In addition, you can export just the settings for select notifiers.  
-Simply run: `::DinkExport <Notifier Section Header Name Without Space>`.  
-For example: `::DinkExport Pet` or `::DinkExport CollectionLog`.
+Simply run: `::dinkexport <notifier section header name without spaces>`.  
+For example: `::dinkexport pet` or `::dinkexport collectionlog`.
 
 Further, you can combine arguments to export specific sets of settings. For example:  
 *Export Slayer & BA Gambles notifiers*: `::dinkexport slayer bagambles`  
@@ -69,7 +69,7 @@ Further, you can combine arguments to export specific sets of settings. For exam
  - `webhooks`: Export primary webhook URLs & webhook overrides
  - `collectionlog`, `pet`, `levels`, `loot`, etc.: Export the settings of one notifier (syntax is: section header with spaces removed)
 
-### Import Configuration via `::DinkImport`
+### Import Configuration via `::dinkimport`
 
 With the output of the above command (`::dinkexport`) copied to your clipboard, you can merge these settings with your own via the `::dinkimport` chat command.
 

--- a/README.md
+++ b/README.md
@@ -49,25 +49,26 @@ Some notifiers require in-game settings to be configured to send chat messages u
 
 Dink allows you to export your current plugin configuration to the clipboard via the `::dinkexport` chat command.
 
-This export includes settings across all of the notifiers. You can share this produced JSON to friends who want to send similarly configured messages.
+You can share this produced JSON to friends who want to send similarly configured messages.
 
-If you want to include webhook URLs in the export, run the `::dinkexport all` chat command.
+This export includes settings across all of the notifiers, but omits webhook URLs. If you also want to include webhook URLs in the export, you can use the `all` parameter to the command: `::dinkexport all`.
 
-Alternatively, if you *only* want to export the webhook URLs, run the `::dinkexport webhooks` chat command.
+If you *only* want to export the webhook URLs, run the `::dinkexport webhooks` chat command.
 
-In addition, you can export just the settings for select notifiers.  
+You can export just the settings for select notifiers.  
 Simply run: `::dinkexport <notifier section header name without spaces>`.  
 For example: `::dinkexport pet` or `::dinkexport collectionlog`.
 
-Further, you can combine arguments to export specific sets of settings. For example:  
-*Export Slayer & BA Gambles notifiers*: `::dinkexport slayer bagambles`  
-*Export webhook overrides only*: `::dinkexport WebhookOverrides`  
-*Export all webhooks & Levels notifier*: `::dinkexport webhooks levels`
+#### Examples
+ - Export notifier settings, primary webhook URLs & webhook override URLs  
+   `::dinkexport all`
+ - Export Slayer & BA Gambles Notifier settings  
+   `::dinkexport slayer bagambles`
+ - Export webhook overrides only  
+   `::dinkexport webhookoverrides`
+ - Export all webhooks & the Levels notifier settings:  
+   `::dinkexport webhooks levels`
 
-#### Available selectors:
- - `all`: Export everything
- - `webhooks`: Export primary webhook URLs & webhook overrides
- - `collectionlog`, `pet`, `levels`, `loot`, etc.: Export the settings of one notifier (syntax is: section header with spaces removed)
 
 ### Import Configuration via `::dinkimport`
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Simply run: `::DinkExport <Notifier Section Header Name Without Space>`.
 For example: `::DinkExport Pet` or `::DinkExport CollectionLog`.
 
 Further, you can combine arguments to export specific sets of settings. For example:  
-*Export Slayer & BA Gambles notifiers*: `::dinkexport bagambles slayer`  
+*Export Slayer & BA Gambles notifiers*: `::dinkexport slayer bagambles`  
 *Export webhook overrides only*: `::dinkexport WebhookOverrides`  
 *Export all webhooks & Levels notifier*: `::dinkexport webhooks levels`
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ Some notifiers require in-game settings to be configured to send chat messages u
 
 ## Chat Commands
 
-### Export Current Configuration via `::dinkexport`
+### Export Current Configuration via `::DinkExport`
 
 Dink allows you to export your current plugin configuration to the clipboard via the `::dinkexport` chat command.
 
-This export includes *every* setting from individual notifiers to the webhook URLs.
+This export includes settings across all of the notifiers. If you want to include webhook URLs in the export, run the `::dinkexport all` chat command.
 
-You can share this produced JSON to friends who want to send similarly configured messages to the same webhook URLs.
+You can share this produced JSON to friends who want to send similarly configured messages.
 
-### Import Configuration via `::dinkimport`
+### Import Configuration via `::DinkImport`
 
 With the output of the above command (`::dinkexport`) copied to your clipboard, you can merge these settings with your own via the `::dinkimport` chat command.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,25 @@ Some notifiers require in-game settings to be configured to send chat messages u
 
 Dink allows you to export your current plugin configuration to the clipboard via the `::dinkexport` chat command.
 
-This export includes settings across all of the notifiers. If you want to include webhook URLs in the export, run the `::dinkexport all` chat command.
+This export includes settings across all of the notifiers. You can share this produced JSON to friends who want to send similarly configured messages.
+
+If you want to include webhook URLs in the export, run the `::dinkexport all` chat command.
+
 Alternatively, if you *only* want to export the webhook URLs, run the `::dinkexport webhooks` chat command.
 
-You can share this produced JSON to friends who want to send similarly configured messages.
+In addition, you can export just the settings for select notifiers.  
+Simply run: `::DinkExport <Notifier Section Header Name Without Space>`.  
+For example: `::DinkExport Pet` or `::DinkExport CollectionLog`.
+
+Further, you can combine arguments to export specific sets of settings. For example:  
+*Export Slayer & BA Gambles notifiers*: `::dinkexport bagambles slayer`  
+*Export webhook overrides only*: `::dinkexport WebhookOverrides`  
+*Export all webhooks & Levels notifier*: `::dinkexport webhooks levels`
+
+#### Available selectors:
+ - `all`: Export everything
+ - `webhooks`: Export primary webhook URLs & webhook overrides
+ - `collectionlog`, `pet`, `levels`, `loot`, etc.: Export the settings of one notifier (syntax is: section header with spaces removed)
 
 ### Import Configuration via `::DinkImport`
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you would like all settings overwritten rather than merged during import, sim
 
 After an import, if the dink plugin settings panel was open, simply close and open it for the updated configuration to be reflected in the user interface.
 
-Note: There is no undo button for this command, so consider making a backup of your current Dink configuration by using the `::dinkexport` command explained above and saving that to a file on your computer.
+Note: There is no undo button for this command, so consider making a backup of your current Dink configuration by using the `::dinkexport all` command explained above and saving that to a file on your computer.
 
 Warning: If you import override URLs for a notifier (that previously did not have any overrides), this will result in the plugin no longer sending messages from that notifier to your old primary URLs.
 As such, you can manually add your primary URLs to the newly populated override URL boxes so that notifications are still sent to the old primary URLs.


### PR DESCRIPTION
* `::dinkexport` - all settings excluding webhook urls
* `::dinkexport all` - all settings including webhook urls
* `::dinkexport webhooks` - only export webhook urls
* `::dinkexport sectionName` - only export notifier settings for a specific section (without url). For example: `::dinkexport bagambles`