### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.3.0
+
 - Major: Add Barbarian Assault high level gambling notifications. (#150)
 - Minor: Add plugin config export and import chat commands. (#155, #160)
 - Minor: Make time units of advanced settings more obvious in the user interface. (#158)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.2.2"
+version = "1.3.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.3.0 most notably features a new notifier for Barbarian Assault high gambles, augments the pet notifier to include the pet name, and improves identification of achievement diary completions.