### PR TITLE
chore: update ba tags in plugin properties files

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Dink
 author=pajlads
 support=https://github.com/pajlads/DinkPlugin
 description=A notifier for sending webhooks to Discord or other custom destinations
-tags=loot,logger,collection,pet,death,xp,level,notifications,discord,speedrun,diary,combat achievements, combat task
+tags=loot,logger,collection,pet,death,xp,level,notifications,discord,speedrun,diary,combat achievements,combat task,barbarian assault,high level gambles
 plugins=dinkplugin.DinkPlugin


### PR DESCRIPTION
Follow-up from #150 (the hub webpage seems to use this file rather than class annotation for searching)