### PR TITLE
feat(death): optionally skip notif if low value lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add setting to skip death notifications with low value of items lost. (#166)
 - Bugfix: Fire skill notification when jumping over a level that matches the configured interval. (#164)
 - Dev: Improve thread-safety of level notifier. (#165)
 

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -630,12 +630,23 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "deathMinValue",
+        name = "Min Lost Value",
+        description = "The minimum value of the lost items for a notification to be sent",
+        position = 43,
+        section = deathSection
+    )
+    default int deathMinValue() {
+        return 0;
+    }
+
+    @ConfigItem(
         keyName = "deathNotifMessage",
         name = "Notification Message",
         description = "The message to be sent through the webhook.<br/>" +
             "Use %USERNAME% to insert your username<br/>" +
             "Use %VALUELOST% to insert the GE value of the stuff you lost",
-        position = 43,
+        position = 44,
         section = deathSection
     )
     default String deathNotifyMessage() {
@@ -646,7 +657,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "deathNotifPvpEnabled",
         name = "Distinguish PvP deaths",
         description = "Should the plugin use a different message for dying in PvP?",
-        position = 44,
+        position = 45,
         section = deathSection
     )
     default boolean deathNotifPvpEnabled() {
@@ -660,7 +671,7 @@ public interface DinkPluginConfig extends Config {
             "Use %PKER% to insert the killer<br/>" +
             "Use %USERNAME% to insert your username<br/>" +
             "Use %VALUELOST% to insert the GE value of the stuff you lost",
-        position = 45,
+        position = 46,
         section = deathSection
     )
     default String deathNotifPvpMessage() {

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -8,6 +8,7 @@ import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.DeathNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.WorldUtils;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
 import net.runelite.api.Item;
 import net.runelite.api.ItemID;
@@ -33,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Singleton
 public class DeathNotifier extends BaseNotifier {
 
@@ -78,8 +80,6 @@ public class DeathNotifier extends BaseNotifier {
     }
 
     private void handleNotify() {
-        Actor pker = identifyPker();
-
         Collection<Item> items = ItemUtils.getItems(client);
         List<Pair<Item, Long>> itemsByPrice = getPricedItems(itemManager, items);
 
@@ -93,6 +93,12 @@ public class DeathNotifier extends BaseNotifier {
             .reduce(Long::sum)
             .orElse(0L);
 
+        if (losePrice < config.deathMinValue()) {
+            log.debug("Skipping death notification below minimum lost value");
+            return;
+        }
+
+        Actor pker = identifyPker();
         String notifyMessage = buildMessage(pker, losePrice);
 
         List<SerializedItemStack> lostStacks = getStacks(itemManager, lostItems, true);

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -93,8 +93,9 @@ public class DeathNotifier extends BaseNotifier {
             .reduce(Long::sum)
             .orElse(0L);
 
-        if (losePrice < config.deathMinValue()) {
-            log.debug("Skipping death notification below minimum lost value");
+        int valueThreshold = config.deathMinValue();
+        if (losePrice < valueThreshold) {
+            log.debug("Skipping death notification; total value of lost items {} is below minimum lost value {}", losePrice, valueThreshold);
             return;
         }
 

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -246,4 +246,27 @@ class DeathNotifierTest extends MockedNotifierTest {
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 
+    @Test
+    void testIgnoreValue() {
+        // prepare mocks
+        when(config.deathMinValue()).thenReturn(TUNA_PRICE + 1);
+        when(client.isPrayerActive(Prayer.PROTECT_ITEM)).thenReturn(true);
+        Item[] items = {
+            new Item(ItemID.RUBY, 1),
+            new Item(ItemID.TUNA, 1),
+            new Item(ItemID.COAL, 1),
+            new Item(ItemID.SHARK, 1),
+            new Item(ItemID.OPAL, 1),
+        };
+        ItemContainer inv = mock(ItemContainer.class);
+        when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(inv);
+        when(inv.getItems()).thenReturn(items);
+
+        // fire event
+        plugin.onActorDeath(new ActorDeath(localPlayer));
+
+        // ensure no notification occurred
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
 }


### PR DESCRIPTION
Defaults to 0gp to preserve old behavior (all notifs, despite value lost)