### PR TITLE
chore: update to gradle 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Minor: Add setting to skip death notifications with low value of items lost. (#166)
 - Bugfix: Fire skill notification when jumping over a level that matches the configured interval. (#164)
-- Dev: Upgrade Gradle from v7.6 to v8.0. (#167)
+- Dev: Upgrade Gradle from v7.6 to v8.0. (#167, #170)
 - Dev: Improve thread-safety of level notifier. (#165)
 
 ## 1.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=4159b938ec734a8388ce03f52aa8f3c7ed0d31f5438622545de4f83a89b79788
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionSha256Sum=1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Scala patch obviously doesn't apply to us, but can still update: https://docs.gradle.org/8.0.1/release-notes.html