### PR TITLE
fix(kc): allow ticks between duration and boss name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Add setting to skip death notifications with low value of items lost. (#166)
+- Bugfix: Associate fight duration to delayed kill count messages. (#171)
 - Bugfix: Fire skill notification when jumping over a level that matches the configured interval. (#164)
 - Dev: Upgrade Gradle from v7.6 to v8.0. (#167, #170)
 - Dev: Improve thread-safety of level notifier. (#165)

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -162,7 +162,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // fire events
         notifier.onGameMessage("Fight duration: 1:54.00 (new personal best)");
-        IntStream.range(0, 9).forEach(i -> notifier.onTick());
+        IntStream.range(0, KillCountNotifier.MAX_BAD_TICKS - 1).forEach(i -> notifier.onTick());
         String gameMessage = "Your Grotesque Guardians kill count is: 79.";
         notifier.onGameMessage(gameMessage);
         notifier.onTick();
@@ -171,6 +171,35 @@ class KillCountNotifierTest extends MockedNotifierTest {
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
             .text(PLAYER_NAME + " has defeated Grotesque Guardians with a new personal best time of 01:54.00 and a completion count of 79")
             .extra(new BossNotificationData("Grotesque Guardians", 79, gameMessage, Duration.ofMinutes(1).plusSeconds(54), true))
+            .playerName(PLAYER_NAME)
+            .type(NotificationType.KILL_COUNT)
+            .build();
+
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            true,
+            body
+        );
+
+        assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
+    }
+
+    @Test
+    void testNotifyExtremeDelayMissingPb() {
+        // more config
+        when(config.killCountInterval()).thenReturn(1);
+
+        // fire events
+        notifier.onGameMessage("Fight duration: 1:54.00 (new personal best)");
+        IntStream.range(0, KillCountNotifier.MAX_BAD_TICKS + 1).forEach(i -> notifier.onTick());
+        String gameMessage = "Your Grotesque Guardians kill count is: 80.";
+        notifier.onGameMessage(gameMessage);
+        notifier.onTick();
+
+        // check notification
+        NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
+            .text(PLAYER_NAME + " has defeated Grotesque Guardians with a completion count of 80")
+            .extra(new BossNotificationData("Grotesque Guardians", 80, gameMessage, null, null))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
             .build();


### PR DESCRIPTION
Since Grotesque Guardians has a long death animation, kill count message can be sent seconds after the fight duration message was sent. As a result, the webhook message did not acknowledge the personal best time (discovered by @Felanbird). Now, we hold onto fight duration data for up to 10 ticks so that it can be associated with the delayed kill count message (but we don't apply this timer in the converse direction to avoid delayed messages for other bosses if time information was not sent/parseable). 