### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.3.1
+
 - Minor: Include pet acquisition milestone in webhook metadata from clan message. (#169)
 - Minor: Add setting to skip death notifications with low value of items lost. (#166)
 - Bugfix: Associate fight duration to delayed kill count messages. (#171)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.3.0"
+version = "1.3.1"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.3.1 fixes a few edge cases (for level and kill count notifiers), augments pet metadata with the acquisition milestone, and allows skipping death notifications if the total value of the lost items is below a configurable threshold. 