### PR TITLE
fix: fire slayer notification beyond 999 points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Minor: Include number of quest completions and quest points in quest notifications. (#178)
 - Minor: Collapse all notifier configuration sections by default. (#176)
 - Minor: Include number of completed entries in collection log notification. (#174)
+- Bugfix: Fire slayer notifications beyond 999 points. (#182)
 - Dev: Add issue tracker link to README. (#179)
 
 ## 1.3.1

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -17,7 +17,7 @@ public class SlayerNotifier extends BaseNotifier {
     private static final Pattern BOSS_REGEX = Pattern.compile("You are granted .+ Slayer XP for completing your boss task against(?: the)? (?<name>.+)\\.$");
     @VisibleForTesting
     static final Pattern SLAYER_TASK_REGEX = Pattern.compile("You have completed your task! You killed (?<task>[\\d,]+ [^.]+)\\..*");
-    private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
+    private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>[\\d,]+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     private volatile String slayerTask = "";
     private final AtomicInteger badTicks = new AtomicInteger(); // used to prevent notifs from using stale data
@@ -93,7 +93,7 @@ public class SlayerNotifier extends BaseNotifier {
         }
 
         int threshold = config.slayerPointThreshold();
-        if (threshold <= 0 || Integer.parseInt(slayerPoints) >= threshold) {
+        if (threshold <= 0 || Integer.parseInt(slayerPoints.replace(",", "")) >= threshold) {
             String notifyMessage = StringUtils.replaceEach(
                 config.slayerNotifyMessage(),
                 new String[] { "%USERNAME%", "%TASK%", "%TASKCOUNT%", "%POINTS%" },

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -51,6 +51,26 @@ class SlayerNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testNotifyThousand() {
+        when(config.slayerPointThreshold()).thenReturn(1000);
+
+        // fire chat messages
+        notifier.onChatMessage("You have completed your task! You killed 245 Cave Kraken. You gained 62,475 xp.");
+        notifier.onChatMessage("You've completed 1,000 tasks and received 1,000 points, giving you a total of 2,584, return to a Slayer master.");
+
+        // check notification message
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            false,
+            NotificationBody.builder()
+                .text(String.format("%s has completed: %s, getting %s points for a total %s tasks completed", PLAYER_NAME, "245 Cave Kraken", "1,000", "1,000"))
+                .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000"))
+                .type(NotificationType.SLAYER)
+                .build()
+        );
+    }
+
+    @Test
     void testNotifyBoss() {
         // fire chat messages
         notifier.onChatMessage("You are granted an extra reward of 5k Slayer XP for completing your boss task against the Cave Kraken boss.");


### PR DESCRIPTION
`SLAYER_COMPLETE_REGEX` was missing a `,` for points (which must be removed for parseInt)