### PR TITLE
fix(slayer): improve thread safety of current task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Minor: Collapse all notifier configuration sections by default. (#176)
 - Minor: Include number of completed entries in collection log notification. (#174, #181)
 - Bugfix: Fire slayer notifications beyond 999 points. (#182)
+- Dev: Improve thread-safety of slayer notifier. (#184)
 - Dev: Update Gradle to 8.0.2 patch version. (#185)
 - Dev: Add issue tracker link to README. (#179)
 


### PR DESCRIPTION
Improves correctness if reset (via swing ui thread) occurs concurrently to slayer completion (on client thread)