### PR TITLE
feat(death): report npc killers in extra data

### DIFF
--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -18,6 +18,7 @@ import net.runelite.api.ParamID;
 import net.runelite.api.Player;
 import net.runelite.api.Prayer;
 import net.runelite.api.Varbits;
+import net.runelite.api.annotations.Varbit;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.vars.AccountType;
@@ -51,6 +52,12 @@ import java.util.stream.Collectors;
 public class DeathNotifier extends BaseNotifier {
 
     private static final String ATTACK_OPTION = "Attack";
+
+    /*
+     * https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bproc,magic_spellbook_redraw%5D.cs2#L115
+     */
+    @Varbit
+    private static final int PVP_ZONE_SPELLBOOK = 6549;
 
     /**
      * Checks whether the actor is alive and interacting with the specified player.
@@ -231,8 +238,10 @@ public class DeathNotifier extends BaseNotifier {
      */
     @Nullable
     private Actor identifyKiller() {
-        boolean pvpEnabled = !WorldUtils.isPvpSafeZone(client) && (client.getVarbitValue(Varbits.IN_WILDERNESS) > 0 || WorldUtils.isPvpWorld(client.getWorldType()));
         Player localPlayer = client.getLocalPlayer();
+        boolean pvpEnabled = !WorldUtils.isPvpSafeZone(client) &&
+            (client.getVarbitValue(Varbits.PVP_SPEC_ORB) == 1 || client.getVarbitValue(PVP_ZONE_SPELLBOOK) == 1 ||
+                client.getVarbitValue(Varbits.IN_WILDERNESS) > 0 || WorldUtils.isPvpWorld(client.getWorldType()));
 
         // O(1) fast path based on last outbound interaction
         Actor lastTarget = this.lastTarget.get();

--- a/src/main/java/dinkplugin/notifiers/data/DeathNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/DeathNotificationData.java
@@ -2,15 +2,36 @@ package dinkplugin.notifiers.data;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
+import java.util.Collection;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class DeathNotificationData extends NotificationData {
-    Long valueLost;
+
+    long valueLost;
+
     boolean isPvp;
+
+    /**
+     * @deprecated in favor of {@link #getKillerName()}
+     */
+    @Nullable
+    @Deprecated
     String pker;
-    List<SerializedItemStack> keptItems;
-    List<SerializedItemStack> lostItems;
+
+    @Nullable
+    String killerName;
+
+    @Nullable
+    Integer killerNpcId;
+
+    @NotNull
+    Collection<SerializedItemStack> keptItems;
+
+    @NotNull
+    Collection<SerializedItemStack> lostItems;
+
 }

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -5,6 +5,7 @@ import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
 import net.runelite.api.WorldType;
 import net.runelite.api.annotations.Varbit;
+import net.runelite.api.annotations.Varp;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -24,6 +25,7 @@ public class WorldUtils {
     private final int CASTLE_WARS_REGION = 9520;
 
     @VisibleForTesting
+    @Varp
     public final int CASTLE_WARS_COUNTDOWN = 380;
     @Varbit
     private final int CASTLE_WARS_X_OFFSET = 156;
@@ -66,7 +68,7 @@ public class WorldUtils {
     }
 
     public boolean isSafeArea(Client client) {
-        return isCastleWars(client) || isPestControl(client) || isPlayerOwnedHouse(client);
+        return isCastleWars(client) || isPestControl(client) || isPlayerOwnedHouse(client) || isLastManStanding(client);
     }
 
     public boolean isSoulWars(Client client) {

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -5,7 +5,6 @@ import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
 import net.runelite.api.WorldType;
 import net.runelite.api.annotations.Varbit;
-import net.runelite.api.annotations.Varp;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -25,7 +24,6 @@ public class WorldUtils {
     private final int CASTLE_WARS_REGION = 9520;
 
     @VisibleForTesting
-    @Varp
     public final int CASTLE_WARS_COUNTDOWN = 380;
     @Varbit
     private final int CASTLE_WARS_X_OFFSET = 156;
@@ -68,7 +66,7 @@ public class WorldUtils {
     }
 
     public boolean isSafeArea(Client client) {
-        return isCastleWars(client) || isPestControl(client) || isPlayerOwnedHouse(client) || isLastManStanding(client);
+        return isCastleWars(client) || isPestControl(client) || isPlayerOwnedHouse(client);
     }
 
     public boolean isSoulWars(Client client) {

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -18,11 +18,9 @@ import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.InteractingChanged;
-import net.runelite.client.game.NPCManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,10 +45,6 @@ class DeathNotifierTest extends MockedNotifierTest {
     @Bind
     @InjectMocks
     DeathNotifier notifier;
-
-    @Bind
-    @Mock
-    NPCManager npcManager;
 
     @Override
     @BeforeEach

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -21,6 +21,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigDescriptor;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.NPCManager;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.http.api.RuneLiteAPI;
 import okhttp3.OkHttpClient;
@@ -72,6 +73,9 @@ abstract class MockedNotifierTest extends MockedTestBase {
 
     @Bind
     protected ItemManager itemManager = Mockito.mock(ItemManager.class);
+
+    @Bind
+    protected NPCManager npcManager = Mockito.mock(NPCManager.class);
 
     @Bind
     protected DinkPlugin plugin = Mockito.spy(DinkPlugin.class);


### PR DESCRIPTION
Closes #189

* Refactor `identifyPker` to `identifyKiller`, which can return a `Player`, a `NPC`, or null
* Add npc id and killer actor name (more generic than `pker`) to `DeathNotificationData`
* Extend `lastTarget` logic for inbound case (`lastIncoming`) so there is another $O(1)$ opportunity before resorting to streams
* Update player comparator in `identifyKiller` to consider team capes and distance to the local player
* Avoid some performance overhead by using `Client#getCachedPlayers` instead of `Client#getPlayers`
* Revert (primary logic change from) #187 given #194
