### PR TITLE
Release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.3.2
+
 - Minor: Include loot source category in notification metadata. (#196)
 - Minor: Avoid death notifications for more safe activities: Barbarian Assault, Chambers of Xeric, Clan Wars, Last Man Standing, Nightmare Zone, Soul Wars, TzHaar Fight Pit. (#194)
 - Minor: Avoid unwarranted settings warnings when world hopping. (#183)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.3.1"
+version = "1.3.2"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
## What's changed

This release includes a good amount of small changes and fixes.
Death notifications spam less by ignoring some safe areas such as LMS.
Chat message warnings in case the Dink config and the Runescape settings are compatible have been improved.
A little UX fix, notifier configuration sections are now collapsed by default.
Fixed a bug that caused the slayer notifier to stop firing when the user receiver more than 999 points (the comma in 1,000 tricker our regex).
Fixed an edge case where not all data about pet acquisitions would be captured due to GIM chat messages being slow at firing.

Link to release with full changelog: https://github.com/pajlads/DinkPlugin/releases/tag/v1.3.2

## Post-PR steps

- [ ]  Make a tag on the main branch commit
- [ ]  Make a GitHub release
- [ ] Update the plugin in the [RuneLite plugin hub](https://github.com/runelite/plugin-hub)
