### PR TITLE
feat: include combat level in skill notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Include combat level in skill notifications. (#203)
+
 ## 1.3.2
 
 - Minor: Include loot source category in notification metadata. (#196)

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ Lastly, Dink makes exceptions for Inferno and TzHaar Fight Cave; deaths in these
       // These are all the skills
       "Skill name": 30,
       "Other skill": 1
+    },
+    "combatLevel": {
+      "value": 50,
+      "increased": false
     }
   },
   "type": "LEVEL"

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -482,10 +482,21 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "levelNotifyCombat",
+        name = "Notify for Combat Levels",
+        description = "Whether notifications should occur for combat level increases",
+        position = 23,
+        section = levelSection
+    )
+    default boolean levelNotifyCombat() {
+        return false;
+    }
+
+    @ConfigItem(
         keyName = "levelInterval",
         name = "Notify Interval",
         description = "Interval between when a notification should be sent",
-        position = 23,
+        position = 24,
         section = levelSection
     )
     default int levelInterval() {
@@ -497,7 +508,7 @@ public interface DinkPluginConfig extends Config {
         name = "Minimum Skill Level",
         description = "The minimum skill level required to send a notification.<br/>" +
             "Useful for filtering out low-level notifications",
-        position = 24,
+        position = 25,
         section = levelSection
     )
     default int levelMinValue() {
@@ -510,7 +521,7 @@ public interface DinkPluginConfig extends Config {
         description = "The message to be sent through the webhook.<br/>" +
             "Use %USERNAME% to insert your username<br/>" +
             "Use %SKILL% to insert the levelled skill(s)",
-        position = 25,
+        position = 26,
         section = levelSection
     )
     default String levelNotifyMessage() {

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -95,8 +95,16 @@ public class LevelNotifier extends BaseNotifier {
             return;
         }
 
+        // Check normal skill level up
         checkLevelUp(config.notifyLevel(), skill, previousLevel, virtualLevel);
 
+        // Skip combat level checking if no level up has occurred
+        if (previousLevel == null || virtualLevel <= previousLevel) {
+            if (currentLevels.containsKey(COMBAT_NAME))
+                return;
+        }
+
+        // Check for combat level increase
         if (COMBAT_COMPONENTS.contains(skill)) {
             int combatLevel = getCombatLevel();
             Integer previousCombatLevel = currentLevels.put(COMBAT_NAME, combatLevel);

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -123,7 +123,7 @@ public class LevelNotifier extends BaseNotifier {
             return;
         }
 
-        if (!checkLevelInterval(previousLevel, currentLevel)) {
+        if (!checkLevelInterval(previousLevel, currentLevel, COMBAT_NAME.equals(skill))) {
             log.trace("Ignoring level up of {} from {} to {} that does not align with config interval", skill, previousLevel, currentLevel);
             return;
         }
@@ -185,11 +185,11 @@ public class LevelNotifier extends BaseNotifier {
             .build());
     }
 
-    private boolean checkLevelInterval(int previous, int level) {
+    private boolean checkLevelInterval(int previous, int level, boolean skipVirtualCheck) {
         if (level < config.levelMinValue())
             return false;
 
-        if (level > 99 && !config.levelNotifyVirtual())
+        if (!skipVirtualCheck && level > 99 && !config.levelNotifyVirtual())
             return false;
 
         int interval = config.levelInterval();

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -157,7 +157,10 @@ public class LevelNotifier extends BaseNotifier {
         if (combatLevel == null) {
             combatLevelUp = null;
             combatLevel = getCombatLevel();
+        } else if (!config.levelNotifyCombat()) {
+            combatLevelUp = null;
         }
+        LevelNotificationData.CombatLevel combatData = new LevelNotificationData.CombatLevel(combatLevel, combatLevelUp);
 
         String thumbnail = count == 1 && (combatLevelUp == null || !combatLevelUp) ? getSkillIcon(levelled.get(0)) : null;
         String fullNotification = StringUtils.replaceEach(
@@ -168,7 +171,7 @@ public class LevelNotifier extends BaseNotifier {
 
         createMessage(config.levelSendImage(), NotificationBody.builder()
             .text(fullNotification)
-            .extra(new LevelNotificationData(lSkills, currentLevels))
+            .extra(new LevelNotificationData(lSkills, currentLevels, combatData))
             .type(NotificationType.LEVEL)
             .thumbnailUrl(thumbnail)
             .build());

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -174,8 +174,21 @@ public class LevelNotifier extends BaseNotifier {
         }
         LevelNotificationData.CombatLevel combatData = new LevelNotificationData.CombatLevel(combatLevel, combatLevelUp);
 
-        // Use skill icon if only one skill was levelled up
-        String thumbnail = count == 1 ? getSkillIcon(levelled.get(0)) : null;
+        // Select relevant thumbnail url
+        String thumbnail;
+        if (count == 1) {
+            // Use skill icon if only one skill was levelled up
+            thumbnail = getSkillIcon(levelled.get(0));
+        } else if (combatLevelUp != null && combatLevelUp && count == 2) {
+            // Upon a combat level increase, use icon of the other combat-related skill that was levelled up
+            String skill = levelled.get(0);
+            if (COMBAT_NAME.equals(skill))
+                skill = levelled.get(1);
+            thumbnail = getSkillIcon(skill);
+        } else {
+            // Fall back to NotificationType#getThumbnail
+            thumbnail = null;
+        }
 
         // Populate message template
         String fullNotification = StringUtils.replaceEach(

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -170,7 +170,7 @@ public class LevelNotifier extends BaseNotifier {
         }
         LevelNotificationData.CombatLevel combatData = new LevelNotificationData.CombatLevel(combatLevel, combatLevelUp);
 
-        String thumbnail = count == 1 && (combatLevelUp == null || !combatLevelUp) ? getSkillIcon(levelled.get(0)) : null;
+        String thumbnail = count == 1 ? getSkillIcon(levelled.get(0)) : null;
         String fullNotification = StringUtils.replaceEach(
             config.levelNotifyMessage(),
             new String[] { "%USERNAME%", "%SKILL%" },

--- a/src/main/java/dinkplugin/notifiers/data/LevelNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/LevelNotificationData.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class LevelNotificationData extends NotificationData {
     Map<String, Integer> levelledSkills;
     Map<String, Integer> allSkills;
+    CombatLevel combatLevel;
 
     @Override
     public List<Field> getFields() {
@@ -34,5 +35,11 @@ public class LevelNotificationData extends NotificationData {
         }
 
         return super.getFields();
+    }
+
+    @Value
+    public static class CombatLevel {
+        int value;
+        Boolean increased;
     }
 }

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -5,6 +5,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.LevelNotificationData;
+import net.runelite.api.Experience;
 import net.runelite.api.Skill;
 import net.runelite.api.events.StatChanged;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,8 @@ class LevelNotifierTest extends MockedNotifierTest {
     @Bind
     @InjectMocks
     LevelNotifier notifier;
+    int initialCombatLevel;
+    LevelNotificationData.CombatLevel unchangedCombatLevel;
 
     @Override
     @BeforeEach
@@ -34,10 +37,15 @@ class LevelNotifierTest extends MockedNotifierTest {
         when(config.notifyLevel()).thenReturn(true);
         when(config.levelSendImage()).thenReturn(false);
         when(config.levelNotifyVirtual()).thenReturn(true);
+        when(config.levelNotifyCombat()).thenReturn(true);
         when(config.levelInterval()).thenReturn(5);
         when(config.levelNotifyMessage()).thenReturn("%USERNAME% has levelled %SKILL%");
 
         // init base level
+        when(client.getRealSkillLevel(any())).thenReturn(1);
+        when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(99);
+        initialCombatLevel = Experience.getCombatLevel(99, 1, 1, 1, 1, 1, 1);
+        unchangedCombatLevel = new LevelNotificationData.CombatLevel(initialCombatLevel, false);
         plugin.onStatChanged(new StatChanged(Skill.AGILITY, 0, 1, 1));
         plugin.onStatChanged(new StatChanged(Skill.ATTACK, 14_000_000, 99, 99));
         plugin.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
@@ -57,7 +65,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 4)))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -77,7 +85,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Hunter to 6")
-                .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hunter", 6)))
+                .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hunter", 6), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -97,7 +105,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Attack to 100")
-                .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hunter", 4)))
+                .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -118,7 +126,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5 and Hunter to 99")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 99)))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 99), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -140,7 +148,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5, Attack to 100, and Hunter to 5")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5)))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
+import java.util.Collections;
 import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,10 +45,12 @@ class LevelNotifierTest extends MockedNotifierTest {
         // init base level
         when(client.getRealSkillLevel(any())).thenReturn(1);
         when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(99);
-        initialCombatLevel = Experience.getCombatLevel(99, 1, 1, 1, 1, 1, 1);
+        when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(10);
+        initialCombatLevel = Experience.getCombatLevel(99, 1, 1, 10, 1, 1, 1);
         unchangedCombatLevel = new LevelNotificationData.CombatLevel(initialCombatLevel, false);
         plugin.onStatChanged(new StatChanged(Skill.AGILITY, 0, 1, 1));
         plugin.onStatChanged(new StatChanged(Skill.ATTACK, 14_000_000, 99, 99));
+        plugin.onStatChanged(new StatChanged(Skill.HITPOINTS, 1200, 10, 10));
         plugin.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
     }
 
@@ -65,7 +68,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 4), unchangedCombatLevel))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -85,7 +88,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Hunter to 6")
-                .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hunter", 6), unchangedCombatLevel))
+                .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 10, "Hunter", 6), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -105,7 +108,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Attack to 100")
-                .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hunter", 4), unchangedCombatLevel))
+                .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -126,7 +129,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5 and Hunter to 99")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hunter", 99), unchangedCombatLevel))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 99), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );
@@ -148,7 +151,57 @@ class LevelNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(PLAYER_NAME + " has levelled Agility to 5, Attack to 100, and Hunter to 5")
-                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), unchangedCombatLevel))
+                .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hitpoints", 10, "Hunter", 5), unchangedCombatLevel))
+                .type(NotificationType.LEVEL)
+                .build()
+        );
+    }
+
+    @Test
+    void testNotifyCombat() {
+        // update config mocks
+        when(config.levelInterval()).thenReturn(18); // won't trigger on hp @ 13, will trigger on combat level @ 36
+
+        // fire skill event
+        when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(13);
+        plugin.onStatChanged(new StatChanged(Skill.HITPOINTS, 2000, 13, 13));
+
+        // let ticks pass
+        IntStream.range(0, 4).forEach(i -> notifier.onTick());
+
+        // verify handled
+        LevelNotificationData.CombatLevel combatLevel = new LevelNotificationData.CombatLevel(initialCombatLevel + 1, true);
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            false,
+            NotificationBody.builder()
+                .text(PLAYER_NAME + " has levelled Combat to 36")
+                .extra(new LevelNotificationData(Collections.emptyMap(), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
+                .type(NotificationType.LEVEL)
+                .build()
+        );
+    }
+
+    @Test
+    void testNotifyTwoCombat() {
+        // update config mocks
+        when(config.levelInterval()).thenReturn(1);
+
+        // fire skill event
+        when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(13);
+        plugin.onStatChanged(new StatChanged(Skill.HITPOINTS, 2000, 13, 13));
+
+        // let ticks pass
+        IntStream.range(0, 4).forEach(i -> notifier.onTick());
+
+        // verify handled
+        LevelNotificationData.CombatLevel combatLevel = new LevelNotificationData.CombatLevel(initialCombatLevel + 1, true);
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            false,
+            NotificationBody.builder()
+                .text(PLAYER_NAME + " has levelled Hitpoints to 13 and Combat to 36")
+                .extra(new LevelNotificationData(ImmutableMap.of("Hitpoints", 13), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
         );


### PR DESCRIPTION
Closes #202 

This approach is robust to disabling the level up widget via the new game setting

Note: combat level is also subject to the same min level and level interval config settings
