### PR TITLE
perf(death): avoid creating intermediate list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Minor: Rescale screenshots to comply with Discord's 8MB size limit. (#200)
 - Minor: Include combat level in skill notifications. (#203)
 - Dev: Update grade wrapper to v8.1 minor version. (#209)
-- Dev: Refactor killer identification in death notifier. (#197)
+- Dev: Refactor killer identification in death notifier. (#197, #210)
 
 ## 1.3.2
 

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -230,7 +230,7 @@ public class DeathNotifier extends BaseNotifier {
 
         // find another player interacting with us (that is preferably not a friend or clan member)
         if (pvpEnabled) {
-            Optional<Player> pker = client.getPlayers().stream()
+            Optional<Player> pker = Arrays.stream(client.getCachedPlayers())
                 .filter(interacting)
                 .min(PK_COMPARATOR.apply(localPlayer)); // O(n)
             if (pker.isPresent())

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -64,7 +64,7 @@ class DeathNotifierTest extends MockedNotifierTest {
 
         // init client mocks
         when(client.getVarbitValue(Varbits.IN_WILDERNESS)).thenReturn(1);
-        when(client.getPlayers()).thenReturn(Collections.emptyList());
+        when(client.getCachedPlayers()).thenReturn(new Player[0]);
         when(client.getCachedNPCs()).thenReturn(new NPC[0]);
         WorldPoint location = new WorldPoint(0, 0, 0);
         when(localPlayer.getWorldLocation()).thenReturn(location);
@@ -151,7 +151,8 @@ class DeathNotifierTest extends MockedNotifierTest {
         Player other = mock(Player.class);
         when(other.getName()).thenReturn(pker);
         when(other.getInteracting()).thenReturn(localPlayer);
-        when(client.getPlayers()).thenReturn(Arrays.asList(mock(Player.class), mock(Player.class), other, mock(Player.class)));
+        Player[] candidates = { mock(Player.class), mock(Player.class), other, mock(Player.class) };
+        when(client.getCachedPlayers()).thenReturn(candidates);
 
         // fire event
         plugin.onActorDeath(new ActorDeath(localPlayer));
@@ -201,7 +202,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         Player other = mock(Player.class);
         when(other.getName()).thenReturn("Rasmus");
         when(other.getInteracting()).thenReturn(localPlayer);
-        when(client.getPlayers()).thenReturn(Collections.singletonList(other));
+        when(client.getCachedPlayers()).thenReturn(new Player[] { other });
         when(client.getVarbitValue(Varbits.IN_WILDERNESS)).thenReturn(0);
 
         // fire event


### PR DESCRIPTION
`Client#getPlayers` is equivalent to creating a list from `Client#getCachedPlayers` (while filtering out nulls). We can directly create a stream from `getCachedPlayers` (like we do for NPCs), so calling `getPlayers` is technically wasteful
