### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.3.3
+
 - Minor: Include NPC killer in death notification metadata. (#207)
 - Minor: Add advanced setting to hide chat when screenshotting. (#208)
 - Minor: Rescale screenshots to comply with Discord's 8MB size limit. (#200)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.3.2"
+version = "1.3.3"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.3.3 includes some minor features, bug fixes, and performance improvements. Most notably, death notification metadata now includes the NPC killer and skill notifications include combat level increases. Further, screenshots are now automatically compressed/rescaled as needed to fit within Discord's file upload limits & the plugin can be configured to momentarily hide the chat box (and PMs) while screenshotting to enhance privacy.

You can find the full release notes at https://github.com/pajlads/DinkPlugin/releases/tag/v1.3.3