### PR TITLE
fix(death): avoid NPE in multi-NPC killer attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Fire death notification when multiple similar NPCs are attacking the player that lack scraped wiki HP data. (#216)
+
 ## 1.3.3
 
 - Minor: Include NPC killer in death notification metadata. (#207)

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -370,9 +370,9 @@ public class DeathNotifier extends BaseNotifier {
                         .thenComparingInt(NPCComposition::getSize) // prefer large
                         .thenComparing(NPCComposition::isMinimapVisible) // prefer visible on minimap
                         .thenComparing(
-                            Comparator.nullsFirst(
-                                Comparator.comparing(comp -> npcManager.getHealth(comp.getId())) // prefer high max health
-                            )
+                            // prefer high max health
+                            comp -> npcManager.getHealth(comp.getId()),
+                            Comparator.nullsFirst(Comparator.naturalOrder())
                         )
                 )
             )


### PR DESCRIPTION
`NPCManager#getHealth` *can* yield null. Due to inadequate use of `Comparator.nullsFirst`, `DeathNotifier` could throw a NPE when comparing multiple NPCs with similar characteristics that are all interacting with the local player. As a result, no death notification message would be fired. This patch correctly applies the transformation on the NPC to get the health *before* calling `nullsFirst`, so null safety is restored. Thanks to RomeoGiggleToess for submitting the stacktrace.
