### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.4.0
+
 - Major: Add notifier to capture player kills while hitsplats are still visible. (#214)
 - Bugfix: Improve reliablity of hidden chat setting for collection log screenshots. (#217)
 - Bugfix: Fire death notification when multiple similar NPCs are attacking the player that lack scraped wiki HP data. (#216)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.3.3"
+version = "1.4.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.4.0 most notably includes a new notifier to capture player kills while hitsplats are still visible. This version also fixes a bug with death notifications when multiple NPCs without wiki HP data are simultaneously attacking the player.