### PR TITLE
chore(DiscordMessageHandler): avoid unnecessary thenAcceptAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Improve test suite reliability for uploading screenshots. (#219)
+
 ## 1.4.0
 
 - Major: Add notifier to capture player kills while hitsplats are still visible. (#214)

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -135,7 +135,7 @@ public class DiscordMessageHandler {
                     unhideWidget(whispersHidden, client, clientThread, WidgetInfo.PRIVATE_CHAT_MESSAGE);
                     return body;
                 })
-                .thenAcceptAsync(body -> sendToMultiple(urlList, body));
+                .thenAccept(body -> sendToMultiple(urlList, body));
         } else {
             sendToMultiple(urlList, reqBodyBuilder);
         }


### PR DESCRIPTION
In `DiscordMessageHandler#createMessage`, the `thenAcceptAsync` call on the screenshot future is unnecessary because the passed consumer already uses an executor to launch tasks not on the client thread (so we do not need to use the default fork-join pool implied by the async future). This change has no noticeable impact on gameplay, but is useful for our unit tests that have screenshots enabled (it reduces the chance that gradle terminates a unit test before some separate thread has finished executing the webhook POST): https://github.com/pajlads/DinkPlugin/issues/213#issuecomment-1518993162
