### PR TITLE
fix: account for instanced regions for safe check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Ignore deaths and player kills in instanced regions that are safe. (#221)
+
 ## 1.4.0
 
 - Major: Add notifier to capture player kills while hitsplats are still visible. (#214)

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -347,7 +347,7 @@ public class DeathNotifier extends BaseNotifier {
             return true; // normally dangerous
 
         // inferno and fight cave are technically safe, but we want death notification regardless
-        int regionId = client.getLocalPlayer().getWorldLocation().getRegionID();
+        int regionId = WorldUtils.getLocation(client).getRegionID();
         return WorldUtils.isInferno(regionId) || WorldUtils.isTzHaarFightCave(regionId);
     }
 

--- a/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
@@ -108,7 +108,7 @@ public class PlayerKillNotifier extends BaseNotifier {
             target.getCombatLevel(),
             equipment,
             sendLocation ? client.getWorld() : null,
-            sendLocation ? target.getWorldLocation() : null,
+            sendLocation ? WorldUtils.getLocation(client, target) : null,
             client.getBoostedSkillLevel(Skill.HITPOINTS),
             myLastDamage
         );

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -2,8 +2,10 @@ package dinkplugin.util;
 
 import com.google.common.collect.ImmutableSet;
 import lombok.experimental.UtilityClass;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.WorldType;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.vars.AccountType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -30,6 +32,17 @@ public class WorldUtils {
     private final int NMZ_REGION = 9033;
     private final int TZHAAR_CAVE = 9551;
     public final @VisibleForTesting int TZHAAR_PIT = 9552;
+
+    public static WorldPoint getLocation(Client client) {
+        return getLocation(client, client.getLocalPlayer());
+    }
+
+    public static WorldPoint getLocation(Client client, Actor actor) {
+        if (client.isInInstancedRegion())
+            return WorldPoint.fromLocalInstance(client, actor.getLocalLocation());
+
+        return actor.getWorldLocation();
+    }
 
     public boolean isIgnoredWorld(Set<WorldType> worldType) {
         return !Collections.disjoint(IGNORED_WORLDS, worldType);
@@ -69,7 +82,7 @@ public class WorldUtils {
     }
 
     public boolean isLastManStanding(Client client) {
-        if (LMS_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID()))
+        if (LMS_REGIONS.contains(getLocation(client).getRegionID()))
             return true;
 
         Widget widget = client.getWidget(WidgetInfo.LMS_KDA);
@@ -90,7 +103,7 @@ public class WorldUtils {
     }
 
     public boolean isSafeArea(Client client) {
-        int regionId = client.getLocalPlayer().getWorldLocation().getRegionID();
+        int regionId = getLocation(client).getRegionID();
 
         if (isBarbarianAssault(regionId) || isChambersOfXeric(regionId) || isInferno(regionId) ||
             isNightmareZone(regionId) || isTzHaarFightCave(regionId) || isPestControl(client)) {


### PR DESCRIPTION
Our hardcoded region IDs in `WorldUtils` are *after* instanced-region adjustment, but we were using region IDs without instanced adjustment.

Impacted notifiers:
* Death (fixes https://togithub.com/pajlads/DinkPlugin/issues/116#issuecomment-1520813460 )
* Loot (for player loot)
* Player Kill (for `extra` and `pkSkipSafe`)
