### PR TITLE
Issue #220 - Update PlayerLookupService.java

### DIFF
--- a/src/main/java/dinkplugin/domain/PlayerLookupService.java
+++ b/src/main/java/dinkplugin/domain/PlayerLookupService.java
@@ -8,8 +8,8 @@ public enum PlayerLookupService {
     CRYSTAL_MATH_LABS("Crystal Math Labs"),
     TEMPLE_OSRS("Temple OSRS"),
     WISE_OLD_MAN("Wise Old Man"),
-    COLLECTION_LOG("Collectionlog.net"); //unsure of name to use, title appears to be Collectionlog.net on site but could be just Collection Log?
-    
+    COLLECTION_LOG("Collectionlog.net");
+
     private final String name;
 
     PlayerLookupService(String name) {

--- a/src/main/java/dinkplugin/domain/PlayerLookupService.java
+++ b/src/main/java/dinkplugin/domain/PlayerLookupService.java
@@ -7,8 +7,9 @@ public enum PlayerLookupService {
     OSRS_HISCORE("OSRS HiScore"),
     CRYSTAL_MATH_LABS("Crystal Math Labs"),
     TEMPLE_OSRS("Temple OSRS"),
-    WISE_OLD_MAN("Wise Old Man");
-
+    WISE_OLD_MAN("Wise Old Man"),
+    COLLECTION_LOG("Collectionlog.net"); //unsure of name to use, title appears to be Collectionlog.net on site but could be just Collection Log?
+    
     private final String name;
 
     PlayerLookupService(String name) {
@@ -26,6 +27,8 @@ public enum PlayerLookupService {
                 return "https://crystalmathlabs.com/track.php?player=" + escapedName;
             case TEMPLE_OSRS:
                 return "https://templeosrs.com/player/overview.php?player=" + escapedName;
+            case COLLECTION_LOG:
+                return "https://collectionlog.net/log/" + escapedName;
             case NONE:
             default:
                 return null;


### PR DESCRIPTION
Aimed to add option as requested in Issue #220. 
Assuming name of 'Collectionlog.net' is fine within the drop down, as that is what appears on the site, but could be wrong with this.

Presents a link to https://collectionlog.net/log/<Username> when clicking on the name from the webhook entry.

![image](https://user-images.githubusercontent.com/132285090/235560524-2177ac2e-8e55-45da-9591-75f1ce2abe1f.png)