### PR TITLE
feat: include discord user in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Include discord user profile in notification metadata. (#226)
 - Minor: Allow player name in Discord notifications to link to CollectionLog.net profile. (#224)
 
 ## 1.4.1

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -259,6 +259,17 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "sendDiscordUser",
+        name = "Send Discord Profile",
+        description = "Whether to send your discord user information to the webhook server via metadata",
+        position = 1010,
+        section = advancedSection
+    )
+    default boolean sendDiscordUser() {
+        return true;
+    }
+
+    @ConfigItem(
         keyName = "discordWebhook", // do not rename; would break old configs
         name = "Primary Webhook URLs",
         description = "The default webhook URL to send notifications to, if no override is specified.<br/>" +

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -1,7 +1,9 @@
 package dinkplugin.message;
 
 import com.google.gson.annotations.SerializedName;
+import dinkplugin.DinkPluginConfig;
 import dinkplugin.notifiers.data.NotificationData;
+import dinkplugin.util.DiscordProfile;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -36,6 +38,15 @@ public class NotificationBody<T extends NotificationData> {
     /*
      * Discord fields
      */
+
+    /**
+     * Information about the current discord user, acquired via RPC (handled by base RuneLite).
+     * <p>
+     * This is only sent if {@link DinkPluginConfig#sendDiscordUser()} is enabled.
+     * While this field is not used by Discord, it can be useful for custom webhook handlers that forward to Discord.
+     */
+    @Nullable
+    DiscordProfile discordUser;
 
     /**
      * Filled in with the text of the notifier (e.g., {@link #getText()} is "Forsen has levelled Attack to 100")

--- a/src/main/java/dinkplugin/util/DiscordProfile.java
+++ b/src/main/java/dinkplugin/util/DiscordProfile.java
@@ -1,0 +1,18 @@
+package dinkplugin.util;
+
+import lombok.Value;
+import net.runelite.discord.DiscordUser;
+import org.jetbrains.annotations.Nullable;
+
+@Value
+public class DiscordProfile {
+    String id;
+    String name;
+    String discriminator;
+    String avatarHash;
+
+    public static DiscordProfile of(@Nullable DiscordUser user) {
+        if (user == null || user.userId == null) return null;
+        return new DiscordProfile(user.userId, user.username, user.discriminator, user.avatar);
+    }
+}

--- a/src/main/java/dinkplugin/util/DiscordProfile.java
+++ b/src/main/java/dinkplugin/util/DiscordProfile.java
@@ -8,11 +8,10 @@ import org.jetbrains.annotations.Nullable;
 public class DiscordProfile {
     String id;
     String name;
-    String discriminator;
     String avatarHash;
 
     public static DiscordProfile of(@Nullable DiscordUser user) {
         if (user == null || user.userId == null) return null;
-        return new DiscordProfile(user.userId, user.username, user.discriminator, user.avatar);
+        return new DiscordProfile(user.userId, user.username, user.avatar);
     }
 }

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -20,6 +20,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigDescriptor;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.discord.DiscordService;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.NPCManager;
 import net.runelite.client.ui.DrawManager;
@@ -69,6 +70,9 @@ abstract class MockedNotifierTest extends MockedTestBase {
     protected ScheduledExecutorService executor = new BlockingExecutor();
 
     @Bind
+    protected DiscordService discordService = Mockito.mock(DiscordService.class);
+
+    @Bind
     protected ChatMessageManager chatManager = Mockito.mock(ChatMessageManager.class);
 
     @Bind
@@ -87,7 +91,7 @@ abstract class MockedNotifierTest extends MockedTestBase {
     protected SettingsManager settingsManager = Mockito.spy(new SettingsManager(gson, client, clientThread, plugin, config, configManager));
 
     @Bind
-    protected DiscordMessageHandler messageHandler = Mockito.spy(new DiscordMessageHandler(gson, client, drawManager, httpClient, config, executor, clientThread));
+    protected DiscordMessageHandler messageHandler = Mockito.spy(new DiscordMessageHandler(gson, client, drawManager, httpClient, config, executor, clientThread, discordService));
 
     @Override
     protected void setUp() {


### PR DESCRIPTION
Includes information about the logged-in Discord user in notification metadata, which can be helpful for webhook consumers that forward to Discord (or involve a Discord community).

```json
{
  "discordUser": {
    "id": "1234567890",
    "name": "Gamer",
    "avatarHash": "abcdefabcdefabcdefabcdef"
  },
  "playerName": "",
  "extra": {},
  "embeds": []
}
```

This information is acquired via RPC (that is already executed by base RuneLite), and can be disabled via an advanced config option.
