### PR TITLE
fix: avoid populating lost items upon inferno death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Minor: Include discord user profile in notification metadata. (#226)
 - Minor: Add setting to allow death notifications during safe activities. (#227)
 - Minor: Allow player name in Discord notifications to link to CollectionLog.net profile. (#224)
+- Bugfix: Ensure lost items metadata is empty upon safe deaths in TzHaar Fight Cave or Inferno. (#230)
 
 ## 1.4.1
 


### PR DESCRIPTION
When user dies in Inferno or TzHaar Fight Cave, it is a safe death that we treat exceptionally in that it should bypass the 'ignore safe' config setting. This patch ensures `lostItems` is not populated upon these exceptional safe deaths. 
