### PR TITLE
fix: avoid combat level notifications with notifier disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Add combat achievement points as rich embed field. (#235)
 - Minor: Use item image as rich embed thumbnail for loot notifications. (#234)
+- Bugfix: Prevent combat level notifications when the notifier is disabled. (#239)
 - Dev: Redefine account type enum to workaround upstream deprecation. (#238)
 
 ## 1.5.0

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -109,7 +109,7 @@ public class LevelNotifier extends BaseNotifier {
         if (COMBAT_COMPONENTS.contains(skill)) {
             int combatLevel = calculateCombatLevel();
             Integer previousCombatLevel = currentLevels.put(COMBAT_NAME, combatLevel);
-            checkLevelUp(config.levelNotifyCombat(), COMBAT_NAME, previousCombatLevel, combatLevel);
+            checkLevelUp(config.notifyLevel() && config.levelNotifyCombat(), COMBAT_NAME, previousCombatLevel, combatLevel);
         }
     }
 

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -208,6 +208,27 @@ class LevelNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testNotifyCombatDisabledLevelNotifier() {
+        // The combat level notification shouldn't fire when notifyLevel is disabled
+
+        // update config mocks
+        when(config.notifyLevel()).thenReturn(false);
+        when(config.levelInterval())
+            .thenReturn(
+                18); // won't trigger on hp @ 13, will trigger on combat level @ 36
+
+        // fire skill event
+        when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(13);
+        plugin.onStatChanged(new StatChanged(Skill.HITPOINTS, 2000, 13, 13));
+
+        // let ticks pass
+        IntStream.range(0, 4).forEach(i -> notifier.onTick());
+
+        // ensure no notification occurred
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
+    @Test
     void testIgnoreInterval() {
         // fire skill event
         plugin.onStatChanged(new StatChanged(Skill.AGILITY, 100, 2, 2));


### PR DESCRIPTION
If level notifier was disabled (but levelNotifyCombat was enabled), combat level increases could still trigger a notification
