### PR TITLE
fix: prefer cached levels for combat level calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Minor: Track points progress towards next combat achievement tier rewards unlock. (#236)
 - Minor: Add combat achievement points as rich embed field. (#235)
 - Minor: Use item image as rich embed thumbnail for loot notifications. (#234)
+- Bugfix: Avoid combat level up notifications when combat level did not change. (#240)
 - Bugfix: Prevent combat level notifications when the notifier is disabled. (#239)
 - Dev: Redefine account type enum to workaround upstream deprecation. (#238)
 

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -24,6 +24,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static net.runelite.api.Experience.MAX_REAL_LEVEL;
+
 @Slf4j
 @Singleton
 public class LevelNotifier extends BaseNotifier {
@@ -86,7 +88,7 @@ public class LevelNotifier extends BaseNotifier {
     private void handleLevelUp(String skill, int level, int xp) {
         if (!isEnabled()) return;
 
-        int virtualLevel = level < 99 ? level : Experience.getLevelForXp(xp); // avoid log(n) query when not needed
+        int virtualLevel = level < MAX_REAL_LEVEL ? level : Experience.getLevelForXp(xp); // avoid log(n) query when not needed
         Integer previousLevel = currentLevels.put(skill, virtualLevel);
 
         if (previousLevel != null && virtualLevel < previousLevel) {
@@ -210,11 +212,11 @@ public class LevelNotifier extends BaseNotifier {
         if (level < config.levelMinValue())
             return false;
 
-        if (!skipVirtualCheck && level > 99 && !config.levelNotifyVirtual())
+        if (!skipVirtualCheck && level > MAX_REAL_LEVEL && !config.levelNotifyVirtual())
             return false;
 
         int interval = config.levelInterval();
-        if (interval <= 1 || level == 99)
+        if (interval <= 1 || level == MAX_REAL_LEVEL)
             return true;
 
         // Check levels in (previous, current] for divisibility by interval
@@ -225,14 +227,21 @@ public class LevelNotifier extends BaseNotifier {
 
     private int calculateCombatLevel() {
         return Experience.getCombatLevel(
-            client.getRealSkillLevel(Skill.ATTACK),
-            client.getRealSkillLevel(Skill.STRENGTH),
-            client.getRealSkillLevel(Skill.DEFENCE),
-            client.getRealSkillLevel(Skill.HITPOINTS),
-            client.getRealSkillLevel(Skill.MAGIC),
-            client.getRealSkillLevel(Skill.RANGED),
-            client.getRealSkillLevel(Skill.PRAYER)
+            getRealLevel(Skill.ATTACK),
+            getRealLevel(Skill.STRENGTH),
+            getRealLevel(Skill.DEFENCE),
+            getRealLevel(Skill.HITPOINTS),
+            getRealLevel(Skill.MAGIC),
+            getRealLevel(Skill.RANGED),
+            getRealLevel(Skill.PRAYER)
         );
+    }
+
+    private int getRealLevel(Skill skill) {
+        Integer cachedLevel = currentLevels.get(skill.getName());
+        return cachedLevel != null
+            ? Math.min(cachedLevel, MAX_REAL_LEVEL)
+            : client.getRealSkillLevel(skill);
     }
 
     private static String getSkillIcon(String skillName) {

--- a/src/main/java/dinkplugin/notifiers/data/LevelNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/LevelNotificationData.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static net.runelite.api.Experience.MAX_REAL_LEVEL;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class LevelNotificationData extends NotificationData {
@@ -20,9 +22,9 @@ public class LevelNotificationData extends NotificationData {
 
     @Override
     public List<Field> getFields() {
-        if (levelledSkills.containsValue(99)) {
+        if (levelledSkills.containsValue(MAX_REAL_LEVEL)) {
             Collection<String> maxed = allSkills.entrySet().stream()
-                .filter(e -> e.getValue() >= 99)
+                .filter(e -> e.getValue() >= MAX_REAL_LEVEL)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toCollection(TreeSet::new));
 


### PR DESCRIPTION
(felanbird):

For some unknown reason, I noticed my normal and virtual levelups were both incorrectly firing combatLevelup notifs, while being at `124.xx` - unsure what could have caused the issue, since I jump around versions while testing.

Notifications were received as follows:

Before this PR:
| Skill | Level | Virtual | combatNotif fired | Correct |
| ----------- | ----------- | -- | -- | -- |
| Attack | 105 | ✔️  | ❌ | ✔️ | 
| Ranged | 108 | ✔️ |✔️ | ❌ |
| Prayer | 88 | ❌ | ✔️ | ❌ |
| Hitpoints | 110 | ✔️  | ✔️ | ❌ |

On this PR:
| Skill | Level | Virtual | combatNotif fired | Correct |
| ----------- | ----------- | -- | -- | -- |
| Ranged | 109 | ✔️ | ❌ | ✔️|
| Prayer | 89 | ❌ | ❌ | ✔️ |
| Prayer | 90 | ❌ | ✔️ | ✔️ |
| Magic | 105 | ✔️ | ❌ | ✔️ |