### PR TITLE
Suggestion: wiki search url for most discord rich embed notifications that can use them.

### DIFF
--- a/src/main/java/dinkplugin/message/placeholder/WikiSearchPlaceholder.java
+++ b/src/main/java/dinkplugin/message/placeholder/WikiSearchPlaceholder.java
@@ -1,0 +1,61 @@
+package dinkplugin.message.placeholder;
+
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Singleton;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static dinkplugin.util.Utils.getWikiSearchUrl;
+
+@Singleton
+public class WikiSearchPlaceholder {
+
+    private final Pattern pattern = Pattern.compile("\\[(?<name>.+?)]\\((?<data>.+?)\\)(?!\\))");
+
+    public Pattern pattern() {
+        return pattern;
+    }
+
+    public String asPlaceholder(String linkName) {
+        return this.asPlaceholder(linkName, null);
+    }
+
+    public String asPlaceholder(String linkName, @Nullable String searchParam) {
+        return String.format("[%s](%s)", linkName, searchParam != null ? searchParam : linkName);
+    }
+
+    public String replacePlaceholder(String inputText) {
+        return replacePlaceholderWith(inputText, this::replacementForLinkName);
+    }
+
+    public String removePlaceholder(String text) {
+        return replacePlaceholderWith(text, (linkName, linkData) -> linkName);
+    }
+
+    public String replacementForLinkName(String linkName, String linkData) {
+        String link =  "[" + linkName + "](" + getWikiSearchUrl(linkData) + ")";
+
+        return link;
+    }
+
+    private String replacePlaceholderWith(String inputText, WikiSearchPlaceholder.Replacer replacer) {
+        Matcher matcher = pattern().matcher(inputText);
+
+        StringBuffer outputText = new StringBuffer();
+        while (matcher.find()) {
+            String linkName = matcher.group("name");
+            String linkData = matcher.group("data");
+            String replacement = replacer.replace(linkName, linkData);
+
+            matcher.appendReplacement(outputText, replacement);
+        }
+        matcher.appendTail(outputText);
+
+        return outputText.toString();
+    }
+
+    private interface Replacer {
+        String replace(String linkName, String linkData);
+    }
+}

--- a/src/main/java/dinkplugin/notifiers/BaseNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/BaseNotifier.java
@@ -4,6 +4,7 @@ import dinkplugin.DinkPluginConfig;
 import dinkplugin.SettingsManager;
 import dinkplugin.message.DiscordMessageHandler;
 import dinkplugin.message.NotificationBody;
+import dinkplugin.message.placeholder.WikiSearchPlaceholder;
 import dinkplugin.util.WorldUtils;
 import net.runelite.api.Client;
 import org.apache.commons.lang3.StringUtils;
@@ -17,6 +18,8 @@ public abstract class BaseNotifier {
 
     @Inject
     protected SettingsManager settingsManager;
+    @Inject
+    protected WikiSearchPlaceholder placeholder;
 
     @Inject
     protected Client client;

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -113,10 +113,14 @@ public class ClueNotifier extends BaseNotifier {
 
         if (totalPrice.get() >= config.clueMinValue()) {
             boolean screenshot = config.clueSendImage() && totalPrice.get() >= config.clueImageMinValue();
+
+            String cluePlaceholder = placeholder.asPlaceholder(clueType, "Clue scroll (" + clueType + ")");
             String notifyMessage = StringUtils.replaceEach(
                 config.clueNotifyMessage(),
-                new String[] { "%USERNAME%", "%CLUE%", "%COUNT%", "%TOTAL_VALUE%", "%LOOT%" },
-                new String[] { Utils.getPlayerName(client), clueType, clueCount, QuantityFormatter.quantityToStackSize(totalPrice.get()), lootMessage.toString() }
+                new String[]{"%USERNAME%", "%CLUE%", "%COUNT%", "%TOTAL_VALUE%", "%LOOT%"},
+                new String[]{Utils.getPlayerName(client),
+                    cluePlaceholder,
+                    clueCount, QuantityFormatter.quantityToStackSize(totalPrice.get()), lootMessage.toString()}
             );
             createMessage(screenshot,
                 NotificationBody.builder()
@@ -134,7 +138,7 @@ public class ClueNotifier extends BaseNotifier {
     private String getItemMessage(SerializedItemStack item, Collection<Embed> embeds) {
         if (config.clueShowItems())
             embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(item.getId())));
-        return ItemUtils.formatStack(item);
+        return ItemUtils.formatStack(item, this.placeholder);
     }
 
     private boolean checkClueTier(String clueType) {

--- a/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
@@ -111,7 +111,7 @@ public class CollectionNotifier extends BaseNotifier {
         String notifyMessage = StringUtils.replaceEach(
             config.collectionNotifyMessage(),
             new String[] { "%USERNAME%", "%ITEM%" },
-            new String[] { Utils.getPlayerName(client), itemName }
+            new String[] { Utils.getPlayerName(client), placeholder.asPlaceholder(itemName) }
         );
 
         // varp isn't updated for a few ticks, so we increment the count locally.

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -102,7 +102,10 @@ public class CombatTaskNotifier extends BaseNotifier {
             String message = StringUtils.replaceEach(
                 crossedThreshold ? config.combatTaskUnlockMessage() : config.combatTaskMessage(),
                 new String[] { "%USERNAME%", "%TIER%", "%TASK%", "%POINTS%", "%TOTAL_POINTS%", "%COMPLETED%" },
-                new String[] { player, tier.toString(), task, String.valueOf(taskPoints), String.valueOf(totalPoints), completedTierName }
+                new String[] { player, tier.toString(),
+                    this.placeholder.asPlaceholder(task),
+                    String.valueOf(taskPoints), String.valueOf(totalPoints),
+                    completedTierName }
             );
 
             createMessage(config.combatTaskSendImage(), NotificationBody.<CombatAchievementData>builder()

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -152,7 +152,9 @@ public class DiaryNotifier extends BaseNotifier {
         String message = StringUtils.replaceEach(
             config.diaryNotifyMessage(),
             new String[] { "%USERNAME%", "%DIFFICULTY%", "%AREA%", "%TOTAL%" },
-            new String[] { player, difficulty.toString(), area, String.valueOf(total) }
+            new String[] { player, difficulty.toString(),
+                placeholder.asPlaceholder(area, difficulty + " " + area + " diary"),
+                String.valueOf(total) }
         );
 
         createMessage(config.diarySendImage(), NotificationBody.builder()

--- a/src/main/java/dinkplugin/notifiers/GambleNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GambleNotifier.java
@@ -3,6 +3,7 @@ package dinkplugin.notifiers;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.placeholder.WikiSearchPlaceholder;
 import dinkplugin.notifiers.data.GambleNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemSearcher;
@@ -80,8 +81,8 @@ public class GambleNotifier extends BaseNotifier {
             .build());
     }
 
-    private static String lootSummary(List<SerializedItemStack> items) {
-        return items.stream().map(ItemUtils::formatStack).collect(Collectors.joining("\n"));
+    private String lootSummary(List<SerializedItemStack> items) {
+        return items.stream().map(item -> ItemUtils.formatStack(item, placeholder)).collect(Collectors.joining("\n"));
     }
 
     private List<SerializedItemStack> serializeItems(ParsedData data) {

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -109,7 +109,7 @@ public class KillCountNotifier extends BaseNotifier {
         String content = StringUtils.replaceEach(
             isPb ? config.killCountBestTimeMessage() : config.killCountMessage(),
             new String[] { "%USERNAME%", "%BOSS%", "%COUNT%", "%TIME%" },
-            new String[] { player, data.getBoss(), String.valueOf(data.getCount()), time }
+            new String[] { player, placeholder.asPlaceholder(data.getBoss()), String.valueOf(data.getCount()), time }
         );
 
         // Prepare body

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -125,7 +125,7 @@ public class LootNotifier extends BaseNotifier {
             if (totalPrice >= minValue) {
                 sendMessage = true;
                 if (lootMessage.length() > 0) lootMessage.append("\n");
-                lootMessage.append(ItemUtils.formatStack(stack));
+                lootMessage.append(ItemUtils.formatStack(stack, placeholder));
                 if (icons) embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(item.getId())));
                 if (max == null || totalPrice > max.getTotalPrice()) {
                     max = stack;

--- a/src/main/java/dinkplugin/notifiers/QuestNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/QuestNotifier.java
@@ -73,7 +73,7 @@ public class QuestNotifier extends BaseNotifier {
         String notifyMessage = StringUtils.replaceEach(
             config.questNotifyMessage(),
             new String[] { "%USERNAME%", "%QUEST%" },
-            new String[] { Utils.getPlayerName(client), parsed }
+            new String[] { Utils.getPlayerName(client), placeholder.asPlaceholder(parsed) }
         );
 
         QuestNotificationData extra = new QuestNotificationData(

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -96,10 +96,12 @@ public class SlayerNotifier extends BaseNotifier {
 
         int threshold = config.slayerPointThreshold();
         if (threshold <= 0 || Integer.parseInt(slayerPoints.replace(",", "")) >= threshold) {
+            Matcher matcher = Pattern.compile("(<taskcount>\\d*)\\s+(<taskmonster>.+)").matcher(task);
+            String taskAsPlaceholder = matcher.group("taskcount") + " " + placeholder.asPlaceholder(matcher.group("taskmonster"));
             String notifyMessage = StringUtils.replaceEach(
                 config.slayerNotifyMessage(),
                 new String[] { "%USERNAME%", "%TASK%", "%TASKCOUNT%", "%POINTS%" },
-                new String[] { Utils.getPlayerName(client), task, slayerCompleted, slayerPoints }
+                new String[] { Utils.getPlayerName(client), taskAsPlaceholder, slayerCompleted, slayerPoints }
             );
 
             createMessage(config.slayerSendImage(), NotificationBody.builder()

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -3,6 +3,7 @@ package dinkplugin.util;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.Embed;
 import dinkplugin.message.Field;
+import dinkplugin.message.placeholder.WikiSearchPlaceholder;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
@@ -16,6 +17,7 @@ import net.runelite.client.util.QuantityFormatter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -120,7 +122,14 @@ public class ItemUtils {
     }
 
     public String formatStack(SerializedItemStack item) {
-        return String.format("%d x %s (%s)", item.getQuantity(), item.getName(), QuantityFormatter.quantityToStackSize(item.getTotalPrice()));
+        return formatStack(item, null);
+    }
+
+    public String formatStack(SerializedItemStack item, @Nullable WikiSearchPlaceholder placeholder) {
+        return String.format("%d x %s (%s)",
+            item.getQuantity(),
+            placeholder != null ? placeholder.asPlaceholder(item.getName()) : item.getName(),
+            QuantityFormatter.quantityToStackSize(item.getTotalPrice()));
     }
 
     public String getItemImageUrl(int itemId) {

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -1,5 +1,6 @@
 package dinkplugin.util;
 
+import com.google.common.net.UrlEscapers;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import dinkplugin.domain.AccountType;
@@ -15,6 +16,7 @@ import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -194,4 +196,7 @@ public class Utils {
         return future;
     }
 
+    public static String getWikiSearchUrl(String search) {
+        return "https://oldschool.runescape.wiki/w/Special:Search?search=" + UrlEscapers.urlPathSegmentEscaper().escape(search);
+    }
 }

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -9,8 +9,10 @@ import dinkplugin.SettingsManager;
 import dinkplugin.domain.AccountType;
 import dinkplugin.domain.PlayerLookupService;
 import dinkplugin.message.DiscordMessageHandler;
+import dinkplugin.message.placeholder.WikiSearchPlaceholder;
 import dinkplugin.util.BlockingClientThread;
 import dinkplugin.util.BlockingExecutor;
+import dinkplugin.util.ItemUtils;
 import dinkplugin.util.TestImageUtil;
 import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
@@ -92,7 +94,10 @@ abstract class MockedNotifierTest extends MockedTestBase {
     protected SettingsManager settingsManager = Mockito.spy(new SettingsManager(gson, client, clientThread, plugin, config, configManager));
 
     @Bind
-    protected DiscordMessageHandler messageHandler = Mockito.spy(new DiscordMessageHandler(gson, client, drawManager, httpClient, config, executor, clientThread, discordService));
+    protected WikiSearchPlaceholder placeholder = new WikiSearchPlaceholder();
+
+    @Bind
+    protected DiscordMessageHandler messageHandler = Mockito.spy(new DiscordMessageHandler(gson, client, drawManager, httpClient, config, executor, clientThread, discordService, placeholder));
 
     @Override
     protected void setUp() {

--- a/src/test/java/dinkplugin/notifiers/placeholder/WikiSearchTest.java
+++ b/src/test/java/dinkplugin/notifiers/placeholder/WikiSearchTest.java
@@ -1,0 +1,70 @@
+package dinkplugin.notifiers.placeholder;
+
+import dinkplugin.message.placeholder.WikiSearchPlaceholder;
+import org.junit.jupiter.api.Test;
+
+import static dinkplugin.util.Utils.getWikiSearchUrl;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WikiSearchTest {
+
+    private final WikiSearchPlaceholder wikiSearch = new WikiSearchPlaceholder();
+
+    @Test
+    public void testWikiSearchPlaceholderReplacing() {
+        String item = "Black king dragon";
+        String placeholder = wikiSearch.asPlaceholder(item);
+        assertEquals(placeholder, "[" + item + "](" + item + ")");
+
+        String replaced = wikiSearch.replacePlaceholder(placeholder);
+        assertEquals("[" + item + "](" + getWikiSearchUrl(item) + ")", replaced);
+    }
+
+    @Test
+    public void testWikiSearchPlaceholderRemoving() {
+        String item = "Black king dragon";
+        String placeholder = wikiSearch.asPlaceholder(item);
+        assertEquals(placeholder, "[" + item + "](" + item + ")");
+
+        String replaced = wikiSearch.removePlaceholder(placeholder);
+        assertEquals(item, replaced);
+    }
+
+    @Test
+    public void testWikiSearchPlaceholderReplacingInsideText() {
+        String text = "dank dank has completed a [medium](Clue scroll (medium)) clue, for a total of 1312. They obtained: 1 x [Ruby](Ruby)";
+
+        String replaced = wikiSearch.replacePlaceholder(text);
+        assertEquals("dank dank has completed a [medium](" + getWikiSearchUrl("Clue scroll (medium)") + ") clue, for a total of 1312. They obtained: 1 x [Ruby](" + getWikiSearchUrl("Ruby") + ")", replaced);
+    }
+
+    @Test
+    public void testWikiSearchPlaceholderRemovingInsideText() {
+        String text = "dank dank has completed a [medium](Clue scroll (medium)) clue, for a total of 1312. They obtained: 1 x [Ruby](Ruby)";
+
+        String replaced = wikiSearch.removePlaceholder(text);
+        assertEquals("dank dank has completed a medium clue, for a total of 1312. They obtained: 1 x Ruby", replaced);
+    }
+
+    @Test
+    public void testWikiSearchPlaceholderWithDataReplacing() {
+        String text = "medium";
+        String linkData = "Clue scroll (medium)";
+        String placeholder = wikiSearch.asPlaceholder(text, linkData);
+        assertEquals(placeholder, "[" + text + "](" + linkData + ")");
+
+        String replaced = wikiSearch.replacePlaceholder(placeholder);
+        assertEquals("[" + text + "](" + getWikiSearchUrl(linkData) + ")", replaced);
+    }
+
+    @Test
+    public void testWikiSearchPlaceholderWithDataRemoving() {
+        String text = "medium";
+        String linkData = "Clue scroll (medium)";
+        String placeholder = wikiSearch.asPlaceholder(text, linkData);
+        assertEquals(placeholder, "[" + text + "](" + linkData + ")");
+
+        String replaced = wikiSearch.removePlaceholder(placeholder);
+        assertEquals(text, replaced);
+    }
+}


### PR DESCRIPTION
Would be nice to have something like this. I probably don't have the time to fix any comments anytime soon, so if this PR is not merge worthy do what you want with this. If I have some time in the future I will try to fix any comments made.

A few examples of notifications:
![image](https://github.com/pajlads/DinkPlugin/assets/17124771/974e4e91-3f53-449a-90ab-a7bc7907a162)
Links to: [https://oldschool.runescape.wiki/w/Special:Search?search=No%20Pressure](https://oldschool.runescape.wiki/w/Special:Search?search=No%20Pressure)
![Discord_KEYiTUApix](https://github.com/pajlads/DinkPlugin/assets/17124771/9245967d-ace8-40b6-843e-149cdddda1fc)
Links to: [https://oldschool.runescape.wiki/w/Special:Search?search=Clue%20scroll%20(medium)](https://oldschool.runescape.wiki/w/Special:Search?search=Clue%20scroll%20(medium)) and [https://oldschool.runescape.wiki/w/Special:Search?search=Ruby](https://oldschool.runescape.wiki/w/Special:Search?search=Ruby)
![image](https://github.com/pajlads/DinkPlugin/assets/17124771/4604da27-ede3-426e-9653-11d2bf0ea8e0)
Links to: [https://oldschool.runescape.wiki/w/Special:Search?search=Tombs%20of%20Amascut:%20Expert%20Mode](https://oldschool.runescape.wiki/w/Special:Search?search=Tombs%20of%20Amascut:%20Expert%20Mode)
