### PR TITLE
feat: include wiki links in rich embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Include relevant wiki links in rich embed content. (#243)
+
 ## 1.5.1
 
 - Minor: Track points progress towards next combat achievement tier rewards unlock. (#236)

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -108,7 +108,7 @@ public class DiscordMessageHandler {
         if (config.discordRichEmbeds()) {
             mBody = injectContent(mBody, sendImage, config);
         } else {
-            mBody = mBody.withComputedDiscordContent(mBody.getText());
+            mBody = mBody.withComputedDiscordContent(mBody.getText().evaluate(false));
         }
 
         MultipartBody.Builder reqBodyBuilder = new MultipartBody.Builder()
@@ -261,7 +261,7 @@ public class DiscordMessageHandler {
                 .author(author)
                 .color(Utils.PINK)
                 .title(type.getTitle())
-                .description(StringUtils.truncate(body.getText(), Embed.MAX_DESCRIPTION_LENGTH))
+                .description(StringUtils.truncate(body.getText().evaluate(config.discordRichEmbeds()), Embed.MAX_DESCRIPTION_LENGTH))
                 .image(screenshot ? new Embed.UrlEmbed("attachment://" + type.getScreenshot()) : null)
                 .thumbnail(new Embed.UrlEmbed(thumbnail))
                 .fields(extra != null ? extra.getFields() : Collections.emptyList())

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -3,6 +3,7 @@ package dinkplugin.message;
 import com.google.gson.annotations.SerializedName;
 import dinkplugin.DinkPluginConfig;
 import dinkplugin.domain.AccountType;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.NotificationData;
 import dinkplugin.util.DiscordProfile;
 import lombok.AllArgsConstructor;
@@ -33,7 +34,7 @@ public class NotificationBody<T extends NotificationData> {
     T extra;
     @NotNull
     @EqualsAndHashCode.Include
-    transient String text;
+    transient Template text;
 
     /*
      * Discord fields

--- a/src/main/java/dinkplugin/message/templating/Evaluable.java
+++ b/src/main/java/dinkplugin/message/templating/Evaluable.java
@@ -1,0 +1,5 @@
+package dinkplugin.message.templating;
+
+public interface Evaluable {
+    String evaluate(boolean rich);
+}

--- a/src/main/java/dinkplugin/message/templating/Replacements.java
+++ b/src/main/java/dinkplugin/message/templating/Replacements.java
@@ -1,0 +1,43 @@
+package dinkplugin.message.templating;
+
+import com.google.common.net.UrlEscapers;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Replacements {
+
+    public Evaluable ofText(String text) {
+        return new Text(text);
+    }
+
+    public Evaluable ofLink(String text, String link) {
+        return new TextWithLink(text, link);
+    }
+
+    public Evaluable ofWiki(String text, String searchPhrase) {
+        return ofLink(text, "https://oldschool.runescape.wiki/w/Special:Search?search=" + UrlEscapers.urlPathSegmentEscaper().escape(searchPhrase));
+    }
+
+    @Value
+    private static class Text implements Evaluable {
+        String text;
+
+        @Override
+        public String evaluate(boolean rich) {
+            return text;
+        }
+    }
+
+    @Value
+    private static class TextWithLink implements Evaluable {
+        String text;
+        String link;
+
+        @Override
+        public String evaluate(boolean rich) {
+            return rich ? String.format("[%s](%s)", text, link) : text;
+        }
+    }
+
+}

--- a/src/main/java/dinkplugin/message/templating/Replacements.java
+++ b/src/main/java/dinkplugin/message/templating/Replacements.java
@@ -19,6 +19,10 @@ public class Replacements {
         return ofLink(text, "https://oldschool.runescape.wiki/w/Special:Search?search=" + UrlEscapers.urlPathSegmentEscaper().escape(searchPhrase));
     }
 
+    public Evaluable ofWiki(String phrase) {
+        return ofWiki(phrase, phrase);
+    }
+
     @Value
     private static class Text implements Evaluable {
         String text;

--- a/src/main/java/dinkplugin/message/templating/Replacements.java
+++ b/src/main/java/dinkplugin/message/templating/Replacements.java
@@ -1,6 +1,7 @@
 package dinkplugin.message.templating;
 
 import com.google.common.net.UrlEscapers;
+import dinkplugin.message.Field;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
 
@@ -23,6 +24,10 @@ public class Replacements {
         return ofWiki(phrase, phrase);
     }
 
+    public Evaluable ofBlock(String language, String content) {
+        return new CodeBlock(language, content);
+    }
+
     @Value
     private static class Text implements Evaluable {
         String text;
@@ -41,6 +46,17 @@ public class Replacements {
         @Override
         public String evaluate(boolean rich) {
             return rich ? String.format("[%s](%s)", text, link) : text;
+        }
+    }
+
+    @Value
+    private static class CodeBlock implements Evaluable {
+        String language;
+        String text;
+
+        @Override
+        public String evaluate(boolean rich) {
+            return rich ? Field.formatBlock(language, text) : text;
         }
     }
 

--- a/src/main/java/dinkplugin/message/templating/Replacements.java
+++ b/src/main/java/dinkplugin/message/templating/Replacements.java
@@ -2,8 +2,11 @@ package dinkplugin.message.templating;
 
 import com.google.common.net.UrlEscapers;
 import dinkplugin.message.Field;
+import dinkplugin.message.templating.impl.JoiningReplacement;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
 
 @UtilityClass
 public class Replacements {
@@ -26,6 +29,13 @@ public class Replacements {
 
     public Evaluable ofBlock(String language, String content) {
         return new CodeBlock(language, content);
+    }
+
+    public Evaluable ofMultiple(String delim, Evaluable... components) {
+        return JoiningReplacement.builder()
+            .delimiter(delim)
+            .components(Arrays.asList(components))
+            .build();
     }
 
     @Value

--- a/src/main/java/dinkplugin/message/templating/Template.java
+++ b/src/main/java/dinkplugin/message/templating/Template.java
@@ -1,0 +1,27 @@
+package dinkplugin.message.templating;
+
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+@Value
+@Builder
+public class Template implements Evaluable {
+    @NotNull
+    String template;
+
+    @Singular
+    Map<String, Evaluable> replacements;
+
+    @Override
+    public String evaluate(boolean rich) {
+        String message = template;
+        for (Map.Entry<String, Evaluable> e : replacements.entrySet()) {
+            message = message.replace(e.getKey(), e.getValue().evaluate(rich));
+        }
+        return message;
+    }
+}

--- a/src/main/java/dinkplugin/message/templating/Template.java
+++ b/src/main/java/dinkplugin/message/templating/Template.java
@@ -6,6 +6,7 @@ import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.Objects;
 
 @Value
 @Builder
@@ -23,5 +24,21 @@ public class Template implements Evaluable {
             message = message.replace(e.getKey(), e.getValue().evaluate(rich));
         }
         return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Template)) return false;
+
+        // custom equals/hashCode based on outputs (rather than inputs) for ease of testing notifiers
+        Template other = (Template) o;
+        return this.evaluate(false).equals(other.evaluate(false))
+            && this.evaluate(true).equals(other.evaluate(true));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.evaluate(false), this.evaluate(true));
     }
 }

--- a/src/main/java/dinkplugin/message/templating/impl/JoiningReplacement.java
+++ b/src/main/java/dinkplugin/message/templating/impl/JoiningReplacement.java
@@ -1,0 +1,33 @@
+package dinkplugin.message.templating.impl;
+
+import dinkplugin.message.templating.Evaluable;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Value
+@Builder
+public class JoiningReplacement implements Evaluable {
+    @Singular
+    List<Evaluable> components;
+    @Builder.Default
+    String delimiter = "";
+
+    @Override
+    public String evaluate(boolean rich) {
+        if (components.isEmpty())
+            return "";
+
+        StringBuilder sb = new StringBuilder();
+        Iterator<Evaluable> it = components.iterator();
+        sb.append(it.next().evaluate(rich));
+        while (it.hasNext()) {
+            sb.append(delimiter);
+            sb.append(it.next().evaluate(rich));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -118,7 +118,7 @@ public class ClueNotifier extends BaseNotifier {
             Template notifyMessage = Template.builder()
                 .template(config.clueNotifyMessage())
                 .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-                .replacement("%CLUE%", Replacements.ofText(clueType))
+                .replacement("%CLUE%", Replacements.ofWiki(clueType, "Clue scroll (" + clueType + ")"))
                 .replacement("%COUNT%", Replacements.ofText(clueCount))
                 .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalPrice.get())))
                 .replacement("%LOOT%", lootMessage.build())

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -4,6 +4,8 @@ import dinkplugin.domain.ClueTier;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
 import dinkplugin.notifiers.data.ClueNotificationData;
@@ -15,7 +17,6 @@ import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.util.QuantityFormatter;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -113,11 +114,14 @@ public class ClueNotifier extends BaseNotifier {
 
         if (totalPrice.get() >= config.clueMinValue()) {
             boolean screenshot = config.clueSendImage() && totalPrice.get() >= config.clueImageMinValue();
-            String notifyMessage = StringUtils.replaceEach(
-                config.clueNotifyMessage(),
-                new String[] { "%USERNAME%", "%CLUE%", "%COUNT%", "%TOTAL_VALUE%", "%LOOT%" },
-                new String[] { Utils.getPlayerName(client), clueType, clueCount, QuantityFormatter.quantityToStackSize(totalPrice.get()), lootMessage.toString() }
-            );
+            Template notifyMessage = Template.builder()
+                .template(config.clueNotifyMessage())
+                .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+                .replacement("%CLUE%", Replacements.ofText(clueType))
+                .replacement("%COUNT%", Replacements.ofText(clueCount))
+                .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalPrice.get())))
+                .replacement("%LOOT%", Replacements.ofText(lootMessage.toString()))
+                .build();
             createMessage(screenshot,
                 NotificationBody.builder()
                     .text(notifyMessage)

--- a/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
@@ -112,7 +112,7 @@ public class CollectionNotifier extends BaseNotifier {
         Template notifyMessage = Template.builder()
             .template(config.collectionNotifyMessage())
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-            .replacement("%ITEM%", Replacements.ofText(itemName))
+            .replacement("%ITEM%", Replacements.ofWiki(itemName))
             .build();
 
         // varp isn't updated for a few ticks, so we increment the count locally.

--- a/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.ItemSearcher;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
@@ -14,7 +16,6 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.inject.Inject;
@@ -108,11 +109,11 @@ public class CollectionNotifier extends BaseNotifier {
     }
 
     private void handleNotify(String itemName) {
-        String notifyMessage = StringUtils.replaceEach(
-            config.collectionNotifyMessage(),
-            new String[] { "%USERNAME%", "%ITEM%" },
-            new String[] { Utils.getPlayerName(client), itemName }
-        );
+        Template notifyMessage = Template.builder()
+            .template(config.collectionNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .replacement("%ITEM%", Replacements.ofText(itemName))
+            .build();
 
         // varp isn't updated for a few ticks, so we increment the count locally.
         // this approach also has the benefit of yielding incrementing values even when

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -1,6 +1,8 @@
 package dinkplugin.notifiers;
 
 import com.google.common.collect.ImmutableMap;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.Utils;
 import dinkplugin.domain.CombatAchievementTier;
 import dinkplugin.message.NotificationBody;
@@ -8,7 +10,6 @@ import dinkplugin.message.NotificationType;
 import dinkplugin.notifiers.data.CombatAchievementData;
 import net.runelite.api.annotations.Varbit;
 import net.runelite.client.callback.ClientThread;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -99,11 +100,15 @@ public class CombatTaskNotifier extends BaseNotifier {
             String completedTierName = completedTier != null ? completedTier.getDisplayName() : "N/A";
 
             String player = Utils.getPlayerName(client);
-            String message = StringUtils.replaceEach(
-                crossedThreshold ? config.combatTaskUnlockMessage() : config.combatTaskMessage(),
-                new String[] { "%USERNAME%", "%TIER%", "%TASK%", "%POINTS%", "%TOTAL_POINTS%", "%COMPLETED%" },
-                new String[] { player, tier.toString(), task, String.valueOf(taskPoints), String.valueOf(totalPoints), completedTierName }
-            );
+            Template message = Template.builder()
+                .template(crossedThreshold ? config.combatTaskUnlockMessage() : config.combatTaskMessage())
+                .replacement("%USERNAME%", Replacements.ofText(player))
+                .replacement("%TIER%", Replacements.ofText(tier.toString()))
+                .replacement("%TASK%", Replacements.ofText(task))
+                .replacement("%POINTS%", Replacements.ofText(String.valueOf(taskPoints)))
+                .replacement("%TOTAL_POINTS%", Replacements.ofText(String.valueOf(totalPoints)))
+                .replacement("%COMPLETED%", Replacements.ofText(completedTierName))
+                .build();
 
             createMessage(config.combatTaskSendImage(), NotificationBody.<CombatAchievementData>builder()
                 .type(NotificationType.COMBAT_ACHIEVEMENT)

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -104,7 +104,7 @@ public class CombatTaskNotifier extends BaseNotifier {
                 .template(crossedThreshold ? config.combatTaskUnlockMessage() : config.combatTaskMessage())
                 .replacement("%USERNAME%", Replacements.ofText(player))
                 .replacement("%TIER%", Replacements.ofText(tier.toString()))
-                .replacement("%TASK%", Replacements.ofText(task))
+                .replacement("%TASK%", Replacements.ofWiki(task))
                 .replacement("%POINTS%", Replacements.ofText(String.valueOf(taskPoints)))
                 .replacement("%TOTAL_POINTS%", Replacements.ofText(String.valueOf(totalPoints)))
                 .replacement("%COMPLETED%", Replacements.ofText(completedTierName))

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.domain.AccountType;
 import dinkplugin.message.Embed;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
 import dinkplugin.message.NotificationBody;
@@ -150,7 +152,7 @@ public class DeathNotifier extends BaseNotifier {
         boolean pk = killer instanceof Player;
         boolean npc = killer instanceof NPC;
         String killerName = killer != null ? StringUtils.defaultIfEmpty(killer.getName(), "?") : null;
-        String notifyMessage = buildMessage(killerName, losePrice, pk, npc);
+        Template notifyMessage = buildMessage(killerName, losePrice, pk, npc);
 
         List<SerializedItemStack> lostStacks = getStacks(itemManager, lostItems, true);
         List<SerializedItemStack> keptStacks = getStacks(itemManager, keptItems, false);
@@ -185,22 +187,24 @@ public class DeathNotifier extends BaseNotifier {
             .build());
     }
 
-    private String buildMessage(String killer, long losePrice, boolean pk, boolean npc) {
+    private Template buildMessage(String killer, long losePrice, boolean pk, boolean npc) {
         boolean pvp = pk && config.deathNotifPvpEnabled();
         String template;
         if (pvp)
             template = config.deathNotifPvpMessage();
         else
             template = config.deathNotifyMessage();
-        String notifyMessage = template
-            .replace("%USERNAME%", Utils.getPlayerName(client))
-            .replace("%VALUELOST%", String.valueOf(losePrice));
+
+        Template.TemplateBuilder builder = Template.builder()
+            .template(template)
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .replacement("%VALUELOST%", Replacements.ofText(String.valueOf(losePrice)));
         if (pvp) {
-            notifyMessage = notifyMessage.replace("%PKER%", killer);
+            builder.replacement("%PKER%", Replacements.ofText(killer));
         } else if (npc) {
-            notifyMessage = notifyMessage.replace("%NPC%", killer);
+            builder.replacement("%NPC%", Replacements.ofText(killer));
         }
-        return notifyMessage;
+        return builder.build();
     }
 
     /**

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -202,7 +202,7 @@ public class DeathNotifier extends BaseNotifier {
         if (pvp) {
             builder.replacement("%PKER%", Replacements.ofText(killer));
         } else if (npc) {
-            builder.replacement("%NPC%", Replacements.ofText(killer));
+            builder.replacement("%NPC%", Replacements.ofWiki(killer));
         }
         return builder.build();
     }

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -3,13 +3,14 @@ package dinkplugin.notifiers;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.DiaryNotificationData;
 import dinkplugin.util.Utils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.inject.Singleton;
@@ -149,11 +150,13 @@ public class DiaryNotifier extends BaseNotifier {
 
         int total = getTotalCompleted();
         String player = Utils.getPlayerName(client);
-        String message = StringUtils.replaceEach(
-            config.diaryNotifyMessage(),
-            new String[] { "%USERNAME%", "%DIFFICULTY%", "%AREA%", "%TOTAL%" },
-            new String[] { player, difficulty.toString(), area, String.valueOf(total) }
-        );
+        Template message = Template.builder()
+            .template(config.diaryNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(player))
+            .replacement("%DIFFICULTY%", Replacements.ofText(difficulty.toString()))
+            .replacement("%AREA%", Replacements.ofText(area))
+            .replacement("%TOTAL%", Replacements.ofText(String.valueOf(total)))
+            .build();
 
         createMessage(config.diarySendImage(), NotificationBody.builder()
             .type(NotificationType.ACHIEVEMENT_DIARY)

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -154,7 +154,7 @@ public class DiaryNotifier extends BaseNotifier {
             .template(config.diaryNotifyMessage())
             .replacement("%USERNAME%", Replacements.ofText(player))
             .replacement("%DIFFICULTY%", Replacements.ofText(difficulty.toString()))
-            .replacement("%AREA%", Replacements.ofText(area))
+            .replacement("%AREA%", Replacements.ofWiki(area, area + " Diary"))
             .replacement("%TOTAL%", Replacements.ofText(String.valueOf(total)))
             .build();
 

--- a/src/main/java/dinkplugin/notifiers/GambleNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GambleNotifier.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GambleNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemSearcher;
@@ -68,11 +70,12 @@ public class GambleNotifier extends BaseNotifier {
         }
         String player = Utils.getPlayerName(client);
         List<SerializedItemStack> items = serializeItems(data);
-        String message = StringUtils.replaceEach(
-            messageFormat,
-            new String[] { "%USERNAME%", "%COUNT%", "%LOOT%" },
-            new String[] { player, String.valueOf(data.gambleCount), lootSummary(items) }
-        );
+        Template message = Template.builder()
+            .template(messageFormat)
+            .replacement("%USERNAME%", Replacements.ofText(player))
+            .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.gambleCount)))
+            .replacement("%LOOT%", Replacements.ofText(lootSummary(items)))
+            .build();
         createMessage(config.gambleSendImage(), NotificationBody.builder()
             .text(message)
             .extra(new GambleNotificationData(data.gambleCount, items))

--- a/src/main/java/dinkplugin/notifiers/GambleNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GambleNotifier.java
@@ -3,8 +3,10 @@ package dinkplugin.notifiers;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Evaluable;
 import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
+import dinkplugin.message.templating.impl.JoiningReplacement;
 import dinkplugin.notifiers.data.GambleNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemSearcher;
@@ -74,7 +76,7 @@ public class GambleNotifier extends BaseNotifier {
             .template(messageFormat)
             .replacement("%USERNAME%", Replacements.ofText(player))
             .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.gambleCount)))
-            .replacement("%LOOT%", Replacements.ofText(lootSummary(items)))
+            .replacement("%LOOT%", lootSummary(items))
             .build();
         createMessage(config.gambleSendImage(), NotificationBody.builder()
             .text(message)
@@ -83,8 +85,10 @@ public class GambleNotifier extends BaseNotifier {
             .build());
     }
 
-    private static String lootSummary(List<SerializedItemStack> items) {
-        return items.stream().map(ItemUtils::formatStack).collect(Collectors.joining("\n"));
+    private static Evaluable lootSummary(List<SerializedItemStack> items) {
+        JoiningReplacement.JoiningReplacementBuilder builder = JoiningReplacement.builder().delimiter("\n");
+        items.forEach(item -> builder.component(ItemUtils.templateStack(item)));
+        return builder.build();
     }
 
     private List<SerializedItemStack> serializeItems(ParsedData data) {

--- a/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
@@ -1,8 +1,9 @@
 package dinkplugin.notifiers;
 
-import dinkplugin.message.Field;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GroupStorageNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
@@ -176,7 +177,10 @@ public class GroupStorageNotifier extends BaseNotifier {
             new String[] { "%USERNAME%", "%DEPOSITED%", "%WITHDRAWN%" },
             new String[] { playerName, depositString, withdrawalString }
         );
-        String formattedText = config.discordRichEmbeds() ? Field.formatBlock("diff", content) : content;
+        Template formattedText = Template.builder()
+            .template("{{s}}")
+            .replacement("{{s}}", Replacements.ofBlock("diff", content))
+            .build();
 
         // Populate metadata
         GroupStorageNotificationData extra = new GroupStorageNotificationData(

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -1,6 +1,8 @@
 package dinkplugin.notifiers;
 
 import dinkplugin.message.Embed;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.TimeUtils;
 import dinkplugin.util.Utils;
@@ -10,7 +12,6 @@ import dinkplugin.notifiers.data.BossNotificationData;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.NPC;
 import net.runelite.api.annotations.Varbit;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -106,11 +107,13 @@ public class KillCountNotifier extends BaseNotifier {
         boolean isPb = data.isPersonalBest() == Boolean.TRUE;
         String player = Utils.getPlayerName(client);
         String time = TimeUtils.format(data.getTime(), TimeUtils.isPreciseTiming(client));
-        String content = StringUtils.replaceEach(
-            isPb ? config.killCountBestTimeMessage() : config.killCountMessage(),
-            new String[] { "%USERNAME%", "%BOSS%", "%COUNT%", "%TIME%" },
-            new String[] { player, data.getBoss(), String.valueOf(data.getCount()), time }
-        );
+        Template content = Template.builder()
+            .template(isPb ? config.killCountBestTimeMessage() : config.killCountMessage())
+            .replacement("%USERNAME%", Replacements.ofText(player))
+            .replacement("%BOSS%", Replacements.ofText(data.getBoss()))
+            .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.getCount())))
+            .replacement("%TIME%", Replacements.ofText(time))
+            .build();
 
         // Prepare body
         NotificationBody.NotificationBodyBuilder<BossNotificationData> body =

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -110,7 +110,7 @@ public class KillCountNotifier extends BaseNotifier {
         Template content = Template.builder()
             .template(isPb ? config.killCountBestTimeMessage() : config.killCountMessage())
             .replacement("%USERNAME%", Replacements.ofText(player))
-            .replacement("%BOSS%", Replacements.ofText(data.getBoss()))
+            .replacement("%BOSS%", Replacements.ofWiki(data.getBoss()))
             .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.getCount())))
             .replacement("%TIME%", Replacements.ofText(time))
             .build();

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -5,6 +5,7 @@ import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
+import dinkplugin.message.templating.impl.JoiningReplacement;
 import dinkplugin.notifiers.data.LevelNotificationData;
 import dinkplugin.util.Utils;
 import lombok.extern.slf4j.Slf4j;
@@ -149,20 +150,22 @@ public class LevelNotifier extends BaseNotifier {
         Map<String, Integer> currentLevels = new HashMap<>(this.currentLevels);
 
         // Build skillMessage and populate lSkills
-        StringBuilder skillMessage = new StringBuilder();
+        JoiningReplacement.JoiningReplacementBuilder skillMessage = JoiningReplacement.builder();
         for (int index = 0; index < count; index++) {
             String skill = levelled.get(index);
             if (index > 0) {
                 if (count > 2) {
-                    skillMessage.append(',');
+                    skillMessage.component(Replacements.ofText(","));
                 }
-                skillMessage.append(' ');
+                skillMessage.component(Replacements.ofText(" "));
                 if (index + 1 == count) {
-                    skillMessage.append("and ");
+                    skillMessage.component(Replacements.ofText("and "));
                 }
             }
             Integer level = currentLevels.get(skill);
-            skillMessage.append(String.format("%s to %s", skill, level));
+            skillMessage
+                .component(Replacements.ofWiki(skill, COMBAT_NAME.equals(skill) ? "Combat level" : skill))
+                .component(Replacements.ofText(" to " + level));
             lSkills.put(skill, level);
         }
 
@@ -197,7 +200,7 @@ public class LevelNotifier extends BaseNotifier {
         Template fullNotification = Template.builder()
             .template(config.levelNotifyMessage())
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-            .replacement("%SKILL%", Replacements.ofText(skillMessage.toString()))
+            .replacement("%SKILL%", skillMessage.build())
             .build();
 
         // Fire notification

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.LevelNotificationData;
 import dinkplugin.util.Utils;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +13,6 @@ import net.runelite.api.GameState;
 import net.runelite.api.Skill;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.StatChanged;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Singleton;
 import java.util.ArrayList;
@@ -191,11 +192,11 @@ public class LevelNotifier extends BaseNotifier {
         }
 
         // Populate message template
-        String fullNotification = StringUtils.replaceEach(
-            config.levelNotifyMessage(),
-            new String[] { "%USERNAME%", "%SKILL%" },
-            new String[] { Utils.getPlayerName(client), skillMessage.toString() }
-        );
+        Template fullNotification = Template.builder()
+            .template(config.levelNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .replacement("%SKILL%", Replacements.ofText(skillMessage.toString()))
+            .build();
 
         // Fire notification
         createMessage(config.levelSendImage(), NotificationBody.builder()

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.LootNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
@@ -137,11 +139,13 @@ public class LootNotifier extends BaseNotifier {
 
         if (sendMessage) {
             boolean screenshot = config.lootSendImage() && totalStackValue >= config.lootImageMinValue();
-            String notifyMessage = StringUtils.replaceEach(
-                config.lootNotifyMessage(),
-                new String[] { "%USERNAME%", "%LOOT%", "%TOTAL_VALUE%", "%SOURCE%" },
-                new String[] { Utils.getPlayerName(client), lootMessage.toString(), QuantityFormatter.quantityToStackSize(totalStackValue), dropper }
-            );
+            Template notifyMessage = Template.builder()
+                .template(config.lootNotifyMessage())
+                .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+                .replacement("%LOOT%", Replacements.ofText(lootMessage.toString()))
+                .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalStackValue)))
+                .replacement("%SOURCE%", Replacements.ofText(dropper))
+                .build();
             createMessage(screenshot,
                 NotificationBody.builder()
                     .text(notifyMessage)

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -5,6 +5,7 @@ import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
 import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
+import dinkplugin.message.templating.impl.JoiningReplacement;
 import dinkplugin.notifiers.data.LootNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
@@ -116,7 +117,7 @@ public class LootNotifier extends BaseNotifier {
         List<SerializedItemStack> serializedItems = new ArrayList<>(reduced.size());
         List<Embed> embeds = new ArrayList<>(icons ? reduced.size() : 0);
 
-        StringBuilder lootMessage = new StringBuilder();
+        JoiningReplacement.JoiningReplacementBuilder lootMessage = JoiningReplacement.builder().delimiter("\n");
         long totalStackValue = 0;
         boolean sendMessage = false;
         SerializedItemStack max = null;
@@ -126,8 +127,7 @@ public class LootNotifier extends BaseNotifier {
             long totalPrice = stack.getTotalPrice();
             if (totalPrice >= minValue) {
                 sendMessage = true;
-                if (lootMessage.length() > 0) lootMessage.append("\n");
-                lootMessage.append(ItemUtils.formatStack(stack));
+                lootMessage.component(ItemUtils.templateStack(stack));
                 if (icons) embeds.add(Embed.ofImage(ItemUtils.getItemImageUrl(item.getId())));
                 if (max == null || totalPrice > max.getTotalPrice()) {
                     max = stack;
@@ -142,7 +142,7 @@ public class LootNotifier extends BaseNotifier {
             Template notifyMessage = Template.builder()
                 .template(config.lootNotifyMessage())
                 .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-                .replacement("%LOOT%", Replacements.ofText(lootMessage.toString()))
+                .replacement("%LOOT%", lootMessage.build())
                 .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalStackValue)))
                 .replacement("%SOURCE%", Replacements.ofText(dropper))
                 .build();

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.PetNotificationData;
 import dinkplugin.util.ItemSearcher;
 import dinkplugin.util.ItemUtils;
@@ -127,8 +129,10 @@ public class PetNotifier extends BaseNotifier {
     }
 
     private void handleNotify() {
-        String notifyMessage = config.petNotifyMessage()
-            .replace("%USERNAME%", Utils.getPlayerName(client));
+        Template notifyMessage = Template.builder()
+            .template(config.petNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .build();
 
         String thumbnail = Optional.ofNullable(petName)
             .filter(s -> !s.isEmpty())

--- a/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.PlayerKillNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
@@ -114,9 +116,11 @@ public class PlayerKillNotifier extends BaseNotifier {
         );
 
         String localPlayer = client.getLocalPlayer().getName();
-        String message = config.pkNotifyMessage()
-            .replace("%USERNAME%", localPlayer)
-            .replace("%TARGET%", target.getName());
+        Template message = Template.builder()
+            .template(config.pkNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(localPlayer))
+            .replacement("%TARGET%", Replacements.ofText(target.getName()))
+            .build();
 
         createMessage(config.pkSendImage(), NotificationBody.builder()
             .type(NotificationType.PLAYER_KILL)

--- a/src/main/java/dinkplugin/notifiers/QuestNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/QuestNotifier.java
@@ -74,7 +74,7 @@ public class QuestNotifier extends BaseNotifier {
         Template notifyMessage = Template.builder()
             .template(config.questNotifyMessage())
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-            .replacement("%QUEST%", Replacements.ofText(parsed))
+            .replacement("%QUEST%", Replacements.ofWiki(parsed))
             .build();
 
         QuestNotificationData extra = new QuestNotificationData(

--- a/src/main/java/dinkplugin/notifiers/QuestNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/QuestNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.QuestUtils;
 import dinkplugin.util.Utils;
 import dinkplugin.notifiers.data.QuestNotificationData;
@@ -11,7 +13,6 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.inject.Inject;
@@ -70,11 +71,11 @@ public class QuestNotifier extends BaseNotifier {
         String parsed = QuestUtils.parseQuestWidget(questText);
         if (parsed == null) return;
 
-        String notifyMessage = StringUtils.replaceEach(
-            config.questNotifyMessage(),
-            new String[] { "%USERNAME%", "%QUEST%" },
-            new String[] { Utils.getPlayerName(client), parsed }
-        );
+        Template notifyMessage = Template.builder()
+            .template(config.questNotifyMessage())
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .replacement("%QUEST%", Replacements.ofText(parsed))
+            .build();
 
         QuestNotificationData extra = new QuestNotificationData(
             parsed,

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -2,9 +2,10 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.Utils;
 import dinkplugin.notifiers.data.SlayerNotificationData;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.inject.Singleton;
@@ -96,11 +97,13 @@ public class SlayerNotifier extends BaseNotifier {
 
         int threshold = config.slayerPointThreshold();
         if (threshold <= 0 || Integer.parseInt(slayerPoints.replace(",", "")) >= threshold) {
-            String notifyMessage = StringUtils.replaceEach(
-                config.slayerNotifyMessage(),
-                new String[] { "%USERNAME%", "%TASK%", "%TASKCOUNT%", "%POINTS%" },
-                new String[] { Utils.getPlayerName(client), task, slayerCompleted, slayerPoints }
-            );
+            Template notifyMessage = Template.builder()
+                .template(config.slayerNotifyMessage())
+                .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+                .replacement("%TASK%", Replacements.ofText(task))
+                .replacement("%TASKCOUNT%", Replacements.ofText(slayerCompleted))
+                .replacement("%POINTS%", Replacements.ofText(slayerPoints))
+                .build();
 
             createMessage(config.slayerSendImage(), NotificationBody.builder()
                 .text(notifyMessage)

--- a/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.QuestUtils;
 import dinkplugin.util.TimeUtils;
 import dinkplugin.util.Utils;
@@ -54,11 +56,13 @@ public class SpeedrunNotifier extends BaseNotifier {
         }
 
         // pb or notifying on non-pb; take the right string and format placeholders
-        String notifyMessage = StringUtils.replaceEach(
-            isPb ? config.speedrunPBMessage() : config.speedrunMessage(),
-            new String[] { "%USERNAME%", "%QUEST%", "%TIME%", "%BEST%" },
-            new String[] { Utils.getPlayerName(client), questName, duration, pb }
-        );
+        Template notifyMessage = Template.builder()
+            .template(isPb ? config.speedrunPBMessage() : config.speedrunMessage())
+            .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
+            .replacement("%QUEST%", Replacements.ofText(questName))
+            .replacement("%TIME%", Replacements.ofText(duration))
+            .replacement("%BEST%", Replacements.ofText(pb))
+            .build();
 
         createMessage(config.speedrunSendImage(), NotificationBody.builder()
             .text(notifyMessage)

--- a/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
@@ -59,7 +59,7 @@ public class SpeedrunNotifier extends BaseNotifier {
         Template notifyMessage = Template.builder()
             .template(isPb ? config.speedrunPBMessage() : config.speedrunMessage())
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-            .replacement("%QUEST%", Replacements.ofText(questName))
+            .replacement("%QUEST%", Replacements.ofWiki(questName))
             .replacement("%TIME%", Replacements.ofText(duration))
             .replacement("%BEST%", Replacements.ofText(pb))
             .build();

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -3,6 +3,8 @@ package dinkplugin.util;
 import com.google.common.collect.ImmutableSet;
 import dinkplugin.message.Embed;
 import dinkplugin.message.Field;
+import dinkplugin.message.templating.Evaluable;
+import dinkplugin.message.templating.Replacements;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
@@ -121,6 +123,15 @@ public class ItemUtils {
 
     public String formatStack(SerializedItemStack item) {
         return String.format("%d x %s (%s)", item.getQuantity(), item.getName(), QuantityFormatter.quantityToStackSize(item.getTotalPrice()));
+    }
+
+    public Evaluable templateStack(SerializedItemStack item) {
+        return Replacements.ofMultiple("",
+            Replacements.ofText(String.valueOf(item.getQuantity())),
+            Replacements.ofText(" x "),
+            Replacements.ofWiki(item.getName()),
+            Replacements.ofText(" (" + QuantityFormatter.quantityToStackSize(item.getTotalPrice()) + ")")
+        );
     }
 
     public String getItemImageUrl(int itemId) {

--- a/src/test/java/dinkplugin/message/templating/TemplateTest.java
+++ b/src/test/java/dinkplugin/message/templating/TemplateTest.java
@@ -1,0 +1,70 @@
+package dinkplugin.message.templating;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TemplateTest {
+
+    @Test
+    void noReplacements() {
+        assertEquals(
+            "Hello world!",
+            Template.builder()
+                .template("Hello world!")
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
+    void unusedReplacements() {
+        assertEquals(
+            "Hello world!",
+            Template.builder()
+                .template("Hello world!")
+                .replacement("%PLANET%", Replacements.ofText("Earth"))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
+    void withReplacements() {
+        assertEquals(
+            "dank dank has killed Monk",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(false)
+        );
+    }
+
+    @Test
+    void withRichReplacements() {
+        assertEquals(
+            "dank dank has killed [Monk](https://oldschool.runescape.wiki/w/Special:Search?search=Monk)",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
+    void missingReplacements() {
+        assertEquals(
+            "%USERNAME% has killed Monk",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(false)
+        );
+    }
+
+}

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -4,6 +4,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.ClueTier;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.ClueNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
@@ -78,7 +79,12 @@ class ClueNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed a %s clue, for a total of %d. They obtained: %s", PLAYER_NAME, "medium", 1312, "1 x Ruby (" + RUBY_PRICE + ")")))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has completed a %s clue, for a total of %d. They obtained: 1 x {{ruby}} (%d)", PLAYER_NAME, "medium", 1312, RUBY_PRICE))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
                 .extra(new ClueNotificationData("medium", 1312, Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"))))
                 .type(NotificationType.CLUE)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -81,7 +81,8 @@ class ClueNotifierTest extends MockedNotifierTest {
             NotificationBody.builder()
                 .text(
                     Template.builder()
-                        .template(String.format("%s has completed a %s clue, for a total of %d. They obtained: 1 x {{ruby}} (%d)", PLAYER_NAME, "medium", 1312, RUBY_PRICE))
+                        .template(String.format("%s has completed a {{tier}} clue, for a total of %d. They obtained: 1 x {{ruby}} (%d)", PLAYER_NAME, 1312, RUBY_PRICE))
+                        .replacement("{{tier}}", Replacements.ofWiki("medium", "Clue scroll (medium)"))
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -4,6 +4,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.ClueTier;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.ClueNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import net.runelite.api.ItemID;
@@ -77,7 +78,7 @@ class ClueNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed a %s clue, for a total of %d. They obtained: %s", PLAYER_NAME, "medium", 1312, "1 x Ruby (" + RUBY_PRICE + ")"))
+                .text(buildTemplate(String.format("%s has completed a %s clue, for a total of %d. They obtained: %s", PLAYER_NAME, "medium", 1312, "1 x Ruby (" + RUBY_PRICE + ")")))
                 .extra(new ClueNotificationData("medium", 1312, Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"))))
                 .type(NotificationType.CLUE)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
@@ -3,6 +3,7 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.CollectionNotificationData;
 import dinkplugin.util.ItemSearcher;
 import net.runelite.api.GameState;
@@ -62,7 +63,7 @@ class CollectionNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has added %s to their collection", PLAYER_NAME, item))
+                .text(buildTemplate(String.format("%s has added %s to their collection", PLAYER_NAME, item)))
                 .extra(new CollectionNotificationData(item, ItemID.SEERCULL, (long) price, 1, TOTAL_ENTRIES))
                 .type(NotificationType.COLLECTION)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
@@ -3,6 +3,7 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.CollectionNotificationData;
 import dinkplugin.util.ItemSearcher;
@@ -63,7 +64,12 @@ class CollectionNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has added %s to their collection", PLAYER_NAME, item)))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has added {{item}} to their collection", PLAYER_NAME))
+                        .replacement("{{item}}", Replacements.ofWiki(item))
+                        .build()
+                )
                 .extra(new CollectionNotificationData(item, ItemID.SEERCULL, (long) price, 1, TOTAL_ENTRIES))
                 .type(NotificationType.COLLECTION)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
@@ -65,7 +65,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed %s combat task: %s", PLAYER_NAME, "Hard", "Whack-a-Mole"))
+                .text(buildTemplate(String.format("%s has completed %s combat task: %s", PLAYER_NAME, "Hard", "Whack-a-Mole")))
                 .extra(new CombatAchievementData(CombatAchievementTier.HARD, "Whack-a-Mole", 3, 200, 85, 189, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
@@ -92,7 +92,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Master", "No Pressure"))
+                .text(buildTemplate(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Master", "No Pressure")))
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 1466, 1466 - 1465, 2005 - 1465, CombatAchievementTier.MASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
@@ -119,7 +119,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Grandmaster", "No Pressure"))
+                .text(buildTemplate(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Grandmaster", "No Pressure")))
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 2005, null, null, CombatAchievementTier.GRANDMASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)

--- a/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
@@ -4,6 +4,8 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.CombatAchievementTier;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.CombatAchievementData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,7 +67,12 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed %s combat task: %s", PLAYER_NAME, "Hard", "Whack-a-Mole")))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has completed %s combat task: {{task}}", PLAYER_NAME, "Hard"))
+                        .replacement("{{task}}", Replacements.ofWiki("Whack-a-Mole"))
+                        .build()
+                )
                 .extra(new CombatAchievementData(CombatAchievementTier.HARD, "Whack-a-Mole", 3, 200, 85, 189, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
@@ -92,7 +99,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Master", "No Pressure")))
+                .text(buildUnlockTemplate("Master", "No Pressure"))
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 1466, 1466 - 1465, 2005 - 1465, CombatAchievementTier.MASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
@@ -119,7 +126,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: %s", PLAYER_NAME, "Grandmaster", "No Pressure")))
+                .text(buildUnlockTemplate("Grandmaster", "No Pressure"))
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 2005, null, null, CombatAchievementTier.GRANDMASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
@@ -157,4 +164,10 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 
+    private static Template buildUnlockTemplate(String tier, String task) {
+        return Template.builder()
+            .template(String.format("%s has unlocked the rewards for the %s tier, by completing the combat task: {{task}}", PLAYER_NAME, tier))
+            .replacement("{{task}}", Replacements.ofWiki(task))
+            .build();
+    }
 }

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -95,7 +95,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, 0))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()
@@ -140,7 +140,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
                 .embeds(embeds)
@@ -166,7 +166,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0))
+                .text(buildTemplate(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0)))
                 .extra(new DeathNotificationData(0L, true, pker, pker, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()
@@ -193,7 +193,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0))
+                .text(buildTemplate(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0)))
                 .extra(new DeathNotificationData(0L, true, pker, pker, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()
@@ -217,7 +217,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, 0))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()
@@ -259,7 +259,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, 0))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, name, NpcID.GUARD, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()
@@ -300,7 +300,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
                 .build()
@@ -340,7 +340,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has died, losing %d gp", PLAYER_NAME, 0))
+                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, kept, Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -4,6 +4,8 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.DeathNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
@@ -250,6 +252,7 @@ class DeathNotifierTest extends MockedNotifierTest {
 
         when(npcManager.getHealth(NpcID.GUARD)).thenReturn(22);
         when(client.getCachedNPCs()).thenReturn(new NPC[] { other });
+        when(config.deathNotifyMessage()).thenReturn("%USERNAME% has died to %NPC%");
 
         // fire event
         plugin.onActorDeath(new ActorDeath(localPlayer));
@@ -259,7 +262,12 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has died to {{npc}}")
+                        .replacement("{{npc}}", Replacements.ofWiki(name))
+                        .build()
+                )
                 .extra(new DeathNotificationData(0L, false, null, name, NpcID.GUARD, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
@@ -61,7 +61,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.ELITE, "Desert", 1))
+                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.ELITE, "Desert", 1)))
                 .extra(new DiaryNotificationData("Desert", AchievementDiary.Difficulty.ELITE, 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -87,7 +87,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
+                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -112,7 +112,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
+                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -138,7 +138,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Western Provinces", total + 1))
+                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Western Provinces", total + 1)))
                 .extra(new DiaryNotificationData("Western Provinces", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -164,7 +164,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
+                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)

--- a/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
@@ -4,6 +4,8 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.DiaryNotificationData;
 import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
@@ -61,7 +63,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.ELITE, "Desert", 1)))
+                .text(buildTemplate(AchievementDiary.Difficulty.ELITE, "Desert", 1))
                 .extra(new DiaryNotificationData("Desert", AchievementDiary.Difficulty.ELITE, 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -87,7 +89,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
+                .text(buildTemplate(AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -112,7 +114,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
+                .text(buildTemplate(AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -138,7 +140,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Western Provinces", total + 1)))
+                .text(buildTemplate(AchievementDiary.Difficulty.HARD, "Western Provinces", total + 1))
                 .extra(new DiaryNotificationData("Western Provinces", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -164,7 +166,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed the %s %s Diary, for a total of %d", PLAYER_NAME, AchievementDiary.Difficulty.HARD, "Karamja", total + 1)))
+                .text(buildTemplate(AchievementDiary.Difficulty.HARD, "Karamja", total + 1))
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
@@ -262,4 +264,10 @@ class DiaryNotifierTest extends MockedNotifierTest {
         return event;
     }
 
+    private static Template buildTemplate(AchievementDiary.Difficulty difficulty, String area, int total) {
+        return Template.builder()
+            .template(String.format("%s has completed the %s {{area}} Diary, for a total of %d", PLAYER_NAME, difficulty, total))
+            .replacement("{{area}}", Replacements.ofWiki(area, area + " Diary"))
+            .build();
+    }
 }

--- a/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GambleNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemSearcher;
@@ -101,7 +103,12 @@ public class GambleNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has received rare loot at gamble count 11: \n\n1 x Dragon chainbody (150K)"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has received rare loot at gamble count 11: \n\n1 x {{dchain}} (150K)")
+                        .replacement("{{dchain}}", Replacements.ofWiki("Dragon chainbody"))
+                        .build()
+                )
                 .extra(new GambleNotificationData(11, Collections.singletonList(new SerializedItemStack(ItemID.DRAGON_CHAINBODY, 1, DRAGON_CHAINBODY_PRICE, "Dragon chainbody"))))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
@@ -62,7 +62,7 @@ public class GambleNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has reached 20 high gambles")
+                .text(buildTemplate(PLAYER_NAME + " has reached 20 high gambles"))
                 .extra(new GambleNotificationData(20, Collections.singletonList(new SerializedItemStack(ItemID.GRANITE_HELM, 1, GRANITE_HELM_PRICE, "Granite helm"))))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
                 .build()
@@ -77,7 +77,7 @@ public class GambleNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has reached 10 high gambles")
+                .text(buildTemplate(PLAYER_NAME + " has reached 10 high gambles"))
                 .extra(new GambleNotificationData(10, Arrays.asList(
                     new SerializedItemStack(ItemID.GRANITE_HELM, 1, GRANITE_HELM_PRICE, "Granite helm"),
                     new SerializedItemStack(ItemID.CLUE_SCROLL_ELITE, 1, ELITE_CLUE_PRICE, "Clue scroll (elite)")
@@ -101,7 +101,7 @@ public class GambleNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has received rare loot at gamble count 11: \n\n1 x Dragon chainbody (150K)")
+                .text(buildTemplate(PLAYER_NAME + " has received rare loot at gamble count 11: \n\n1 x Dragon chainbody (150K)"))
                 .extra(new GambleNotificationData(11, Collections.singletonList(new SerializedItemStack(ItemID.DRAGON_CHAINBODY, 1, DRAGON_CHAINBODY_PRICE, "Dragon chainbody"))))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
@@ -4,6 +4,8 @@ import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.domain.AccountType;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GroupStorageNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import net.runelite.api.InventoryID;
@@ -298,7 +300,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
 
     private void verifyNotification(GroupStorageNotificationData extra, String deposited, String withdrawn) {
         String text = String.format(
-            "```diff\n%s has deposited:\n%s\n\n%s has withdrawn:\n%s\n```",
+            "%s has deposited:\n%s\n\n%s has withdrawn:\n%s",
             PLAYER_NAME, deposited, PLAYER_NAME, withdrawn
         );
 
@@ -306,7 +308,12 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(text)
+                .text(
+                    Template.builder()
+                        .template("{{x}}")
+                        .replacement("{{x}}", Replacements.ofBlock("diff", text))
+                        .build()
+                )
                 .extra(extra)
                 .type(NotificationType.GROUP_STORAGE)
                 .playerName(PLAYER_NAME)

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -1,6 +1,8 @@
 package dinkplugin.notifiers;
 
 import com.google.inject.testing.fieldbinder.Bind;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.TimeUtils;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -57,7 +59,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(buildTemplate(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 420"))
+            .text(buildTemplate("King Black Dragon", 420))
             .extra(new BossNotificationData("King Black Dragon", 420, gameMessage, null, null))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -88,7 +90,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 1"))
+                .text(buildTemplate("King Black Dragon", 1))
                 .extra(new BossNotificationData("King Black Dragon", 1, gameMessage, null, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -140,7 +142,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56.50 and a completion count of 12"))
+            .text(buildPbTemplate("Zulrah", "00:56.50", 12))
             .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -169,7 +171,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(buildTemplate(PLAYER_NAME + " has defeated Grotesque Guardians with a new personal best time of 01:54.00 and a completion count of 79"))
+            .text(buildPbTemplate("Grotesque Guardians", "01:54.00", 79))
             .extra(new BossNotificationData("Grotesque Guardians", 79, gameMessage, Duration.ofMinutes(1).plusSeconds(54), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -198,7 +200,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(buildTemplate(PLAYER_NAME + " has defeated Grotesque Guardians with a completion count of 80"))
+            .text(buildTemplate("Grotesque Guardians", 80))
             .extra(new BossNotificationData("Grotesque Guardians", 80, gameMessage, null, null))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -229,7 +231,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 01:00:56.50 and a completion count of 1"))
+                .text(buildPbTemplate("Zulrah", "01:00:56.50", 1))
                 .extra(new BossNotificationData("Zulrah", 1, gameMessage, Duration.ofHours(1).plusSeconds(56).plusMillis(500), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -251,7 +253,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56 and a completion count of 13"))
+            .text(buildPbTemplate("Zulrah", "00:56", 13))
             .extra(new BossNotificationData("Zulrah", 13, gameMessage, Duration.ofSeconds(56), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -282,7 +284,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Chambers of Xeric with a new personal best time of 36:04.20 and a completion count of 125"))
+                .text(buildPbTemplate("Chambers of Xeric", "36:04.20", 125))
                 .extra(new BossNotificationData("Chambers of Xeric", 125, gameMessage, Duration.ofMinutes(36).plusSeconds(4).plusMillis(200), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -307,7 +309,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Chambers of Xeric with a completion count of 150"))
+                .text(buildTemplate("Chambers of Xeric", 150))
                 .extra(new BossNotificationData("Chambers of Xeric", 150, gameMessage, Duration.ofMinutes(46).plusSeconds(31).plusMillis(800), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -331,7 +333,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 10:25.00 and a completion count of 10"))
+                .text(buildPbTemplate("Crystalline Hunllef", "10:25.00", 10))
                 .extra(new BossNotificationData("Crystalline Hunllef", 10, gameMessage, Duration.ofMinutes(10).plusSeconds(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -355,7 +357,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 06:30.00 and a completion count of 69"))
+                .text(buildPbTemplate("Tempoross", "06:30.00", 69))
                 .extra(new BossNotificationData("Tempoross", 69, gameMessage, Duration.ofMinutes(6).plusSeconds(30), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -379,7 +381,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 25:00.00 and a completion count of 8"))
+                .text(buildPbTemplate("Tombs of Amascut: Expert Mode", "25:00.00", 8))
                 .extra(new BossNotificationData("Tombs of Amascut: Expert Mode", 8, gameMessage, Duration.ofMinutes(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -403,7 +405,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a completion count of 12"))
+                .text(buildTemplate("Zulrah", 12))
                 .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(59).plusMillis(300), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -486,4 +488,17 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 
+    private static Template buildTemplate(String boss, int count) {
+        return Template.builder()
+            .template(PLAYER_NAME + " has defeated {{boss}} with a completion count of " + count)
+            .replacement("{{boss}}", Replacements.ofWiki(boss))
+            .build();
+    }
+
+    private static Template buildPbTemplate(String boss, String time, int count) {
+        return Template.builder()
+            .template(String.format("%s has defeated {{boss}} with a new personal best time of %s and a completion count of %d", PLAYER_NAME, time, count))
+            .replacement("{{boss}}", Replacements.ofWiki(boss))
+            .build();
+    }
 }

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -57,7 +57,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 420")
+            .text(buildTemplate(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 420"))
             .extra(new BossNotificationData("King Black Dragon", 420, gameMessage, null, null))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -88,7 +88,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 1")
+                .text(buildTemplate(PLAYER_NAME + " has defeated King Black Dragon with a completion count of 1"))
                 .extra(new BossNotificationData("King Black Dragon", 1, gameMessage, null, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -140,7 +140,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56.50 and a completion count of 12")
+            .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56.50 and a completion count of 12"))
             .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(56).plusMillis(500), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -169,7 +169,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(PLAYER_NAME + " has defeated Grotesque Guardians with a new personal best time of 01:54.00 and a completion count of 79")
+            .text(buildTemplate(PLAYER_NAME + " has defeated Grotesque Guardians with a new personal best time of 01:54.00 and a completion count of 79"))
             .extra(new BossNotificationData("Grotesque Guardians", 79, gameMessage, Duration.ofMinutes(1).plusSeconds(54), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -198,7 +198,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(PLAYER_NAME + " has defeated Grotesque Guardians with a completion count of 80")
+            .text(buildTemplate(PLAYER_NAME + " has defeated Grotesque Guardians with a completion count of 80"))
             .extra(new BossNotificationData("Grotesque Guardians", 80, gameMessage, null, null))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -229,7 +229,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 01:00:56.50 and a completion count of 1")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 01:00:56.50 and a completion count of 1"))
                 .extra(new BossNotificationData("Zulrah", 1, gameMessage, Duration.ofHours(1).plusSeconds(56).plusMillis(500), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -251,7 +251,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
 
         // check notification
         NotificationBody<BossNotificationData> body = NotificationBody.<BossNotificationData>builder()
-            .text(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56 and a completion count of 13")
+            .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a new personal best time of 00:56 and a completion count of 13"))
             .extra(new BossNotificationData("Zulrah", 13, gameMessage, Duration.ofSeconds(56), true))
             .playerName(PLAYER_NAME)
             .type(NotificationType.KILL_COUNT)
@@ -282,7 +282,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Chambers of Xeric with a new personal best time of 36:04.20 and a completion count of 125")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Chambers of Xeric with a new personal best time of 36:04.20 and a completion count of 125"))
                 .extra(new BossNotificationData("Chambers of Xeric", 125, gameMessage, Duration.ofMinutes(36).plusSeconds(4).plusMillis(200), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -307,7 +307,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Chambers of Xeric with a completion count of 150")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Chambers of Xeric with a completion count of 150"))
                 .extra(new BossNotificationData("Chambers of Xeric", 150, gameMessage, Duration.ofMinutes(46).plusSeconds(31).plusMillis(800), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -331,7 +331,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 10:25.00 and a completion count of 10")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Crystalline Hunllef with a new personal best time of 10:25.00 and a completion count of 10"))
                 .extra(new BossNotificationData("Crystalline Hunllef", 10, gameMessage, Duration.ofMinutes(10).plusSeconds(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -355,7 +355,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 06:30.00 and a completion count of 69")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Tempoross with a new personal best time of 06:30.00 and a completion count of 69"))
                 .extra(new BossNotificationData("Tempoross", 69, gameMessage, Duration.ofMinutes(6).plusSeconds(30), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -379,7 +379,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 25:00.00 and a completion count of 8")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Tombs of Amascut: Expert Mode with a new personal best time of 25:00.00 and a completion count of 8"))
                 .extra(new BossNotificationData("Tombs of Amascut: Expert Mode", 8, gameMessage, Duration.ofMinutes(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
@@ -403,7 +403,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             true,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has defeated Zulrah with a completion count of 12")
+                .text(buildTemplate(PLAYER_NAME + " has defeated Zulrah with a completion count of 12"))
                 .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(59).plusMillis(300), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -67,7 +67,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Agility to 5")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -87,7 +87,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Hunter to 6")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Hunter to 6"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 10, "Hunter", 6), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -107,7 +107,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Attack to 100")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Attack to 100"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -128,7 +128,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Agility to 5 and Hunter to 99")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5 and Hunter to 99"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 99), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -150,7 +150,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Agility to 5, Attack to 100, and Hunter to 5")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5, Attack to 100, and Hunter to 5"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hitpoints", 10, "Hunter", 5), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -175,7 +175,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Combat to 36")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Combat to 36"))
                 .extra(new LevelNotificationData(Collections.emptyMap(), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -200,7 +200,7 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has levelled Hitpoints to 13 and Combat to 36")
+                .text(buildTemplate(PLAYER_NAME + " has levelled Hitpoints to 13 and Combat to 36"))
                 .extra(new LevelNotificationData(ImmutableMap.of("Hitpoints", 13), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
                 .type(NotificationType.LEVEL)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -4,11 +4,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.LevelNotificationData;
 import net.runelite.api.Experience;
 import net.runelite.api.Skill;
 import net.runelite.api.events.StatChanged;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
@@ -67,7 +70,12 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{skill}} to 5")
+                        .replacement("{{skill}}", Replacements.ofWiki("Agility"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -87,7 +95,12 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Hunter to 6"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{skill}} to 6")
+                        .replacement("{{skill}}", Replacements.ofWiki("Hunter"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 10, "Hunter", 6), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -107,7 +120,12 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Attack to 100"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{skill}} to 100")
+                        .replacement("{{skill}}", Replacements.ofWiki("Attack"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), ImmutableMap.of("Agility", 1, "Attack", 100, "Hitpoints", 10, "Hunter", 4), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -128,7 +146,13 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5 and Hunter to 99"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{s1}} to 5 and {{s2}} to 99")
+                        .replacement("{{s1}}", Replacements.ofWiki("Agility"))
+                        .replacement("{{s2}}", Replacements.ofWiki("Hunter"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), ImmutableMap.of("Agility", 5, "Attack", 99, "Hitpoints", 10, "Hunter", 99), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -150,7 +174,14 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Agility to 5, Attack to 100, and Hunter to 5"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{s1}} to 5, {{s2}} to 100, and {{s3}} to 5")
+                        .replacement("{{s1}}", Replacements.ofWiki("Agility"))
+                        .replacement("{{s2}}", Replacements.ofWiki("Attack"))
+                        .replacement("{{s3}}", Replacements.ofWiki("Hunter"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), ImmutableMap.of("Agility", 5, "Attack", 100, "Hitpoints", 10, "Hunter", 5), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -175,7 +206,12 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Combat to 36"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{skill}} to 36")
+                        .replacement("{{skill}}", Replacements.ofWiki("Combat", "Combat level"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(Collections.emptyMap(), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -200,7 +236,13 @@ class LevelNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has levelled Hitpoints to 13 and Combat to 36"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has levelled {{s1}} to 13 and {{s2}} to 36")
+                        .replacement("{{s1}}", Replacements.ofWiki("Hitpoints"))
+                        .replacement("{{s2}}", Replacements.ofWiki("Combat", "Combat level"))
+                        .build()
+                )
                 .extra(new LevelNotificationData(ImmutableMap.of("Hitpoints", 13), ImmutableMap.of("Agility", 1, "Attack", 99, "Hitpoints", 13, "Hunter", 4), combatLevel))
                 .type(NotificationType.LEVEL)
                 .build()
@@ -208,9 +250,8 @@ class LevelNotifierTest extends MockedNotifierTest {
     }
 
     @Test
-    void testNotifyCombatDisabledLevelNotifier() {
-        // The combat level notification shouldn't fire when notifyLevel is disabled
-
+    @DisplayName("Ensure the combat level notification isn't fired when notifyLevel is disabled")
+    void testDisabledCombatLevel() {
         // update config mocks
         when(config.notifyLevel()).thenReturn(false);
         when(config.levelInterval())

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.LootNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import net.runelite.api.ItemID;
@@ -84,7 +86,12 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", name, RUBY_PRICE)))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d) from %s for %d gp", PLAYER_NAME, RUBY_PRICE, name, RUBY_PRICE))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC))
                 .type(NotificationType.LOOT)
                 .build()
@@ -116,7 +123,12 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, RUBY_PRICE)))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d) from %s for %d gp", PLAYER_NAME, RUBY_PRICE, LOOTED_NAME, RUBY_PRICE))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET))
                 .type(NotificationType.LOOT)
                 .build()
@@ -145,7 +157,12 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", source, RUBY_PRICE)))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d) from %s for %d gp", PLAYER_NAME, RUBY_PRICE, source, RUBY_PRICE))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), source, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -180,7 +197,12 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, QuantityFormatter.quantityToStackSize(RUBY_PRICE + TUNA_PRICE))))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d) from %s for %s gp", PLAYER_NAME, RUBY_PRICE, LOOTED_NAME, QuantityFormatter.quantityToStackSize(RUBY_PRICE + TUNA_PRICE)))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER))
                 .type(NotificationType.LOOT)
                 .build()
@@ -220,12 +242,17 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // verify notification message
-        String loot = String.format("1 x Ruby (%d)\n1 x Opal (%d)", RUBY_PRICE, OPAL_PRICE);
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total))))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d)\n1 x {{opal}} (%d) from %s for %s gp", PLAYER_NAME, RUBY_PRICE, OPAL_PRICE, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total)))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .replacement("{{opal}}", Replacements.ofWiki("Opal"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.OPAL, 1, OPAL_PRICE, "Opal"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -252,12 +279,16 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // verify notification message
-        String loot = String.format("5 x Tuna (%d)", 5 * TUNA_PRICE);
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total))))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 5 x {{tuna}} (%d) from %s for %s gp", PLAYER_NAME, 5 * TUNA_PRICE, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total)))
+                        .replacement("{{tuna}}", Replacements.ofWiki("Tuna"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 5, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -289,7 +320,12 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Abyssal Whip (" + formattedPrice + ")", source, formattedPrice)))
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{whip}} (%s) from %s for %s gp", PLAYER_NAME, formattedPrice, source, formattedPrice))
+                        .replacement("{{whip}}", Replacements.ofWiki("Abyssal Whip"))
+                        .build()
+                )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.ABYSSAL_WHIP, 1, whipPrice, "Abyssal Whip")), source, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -84,7 +84,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", name, RUBY_PRICE))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", name, RUBY_PRICE)))
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC))
                 .type(NotificationType.LOOT)
                 .build()
@@ -116,7 +116,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, RUBY_PRICE))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, RUBY_PRICE)))
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET))
                 .type(NotificationType.LOOT)
                 .build()
@@ -145,7 +145,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", source, RUBY_PRICE))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %d gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", source, RUBY_PRICE)))
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), source, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -180,7 +180,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, QuantityFormatter.quantityToStackSize(RUBY_PRICE + TUNA_PRICE)))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Ruby (" + RUBY_PRICE + ")", LOOTED_NAME, QuantityFormatter.quantityToStackSize(RUBY_PRICE + TUNA_PRICE))))
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER))
                 .type(NotificationType.LOOT)
                 .build()
@@ -225,7 +225,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total)))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total))))
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.OPAL, 1, OPAL_PRICE, "Opal"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -257,7 +257,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total)))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, loot, LOOTED_NAME, QuantityFormatter.quantityToStackSize(total))))
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 5, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()
@@ -289,7 +289,7 @@ class LootNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Abyssal Whip (" + formattedPrice + ")", source, formattedPrice))
+                .text(buildTemplate(String.format("%s has looted: %s from %s for %s gp", PLAYER_NAME, "1 x Abyssal Whip (" + formattedPrice + ")", source, formattedPrice)))
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.ABYSSAL_WHIP, 1, whipPrice, "Abyssal Whip")), source, LootRecordType.EVENT))
                 .type(NotificationType.LOOT)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -9,6 +9,7 @@ import dinkplugin.SettingsManager;
 import dinkplugin.domain.AccountType;
 import dinkplugin.domain.PlayerLookupService;
 import dinkplugin.message.DiscordMessageHandler;
+import dinkplugin.message.templating.Template;
 import dinkplugin.util.BlockingClientThread;
 import dinkplugin.util.BlockingExecutor;
 import dinkplugin.util.TestImageUtil;
@@ -133,6 +134,10 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(item.getName()).thenReturn(name);
         when(itemManager.getItemComposition(id)).thenReturn(item);
         when(itemManager.canonicalize(id)).thenReturn(id);
+    }
+
+    protected static Template buildTemplate(String text) {
+        return Template.builder().template(text).build();
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
@@ -54,7 +54,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(null, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .type(NotificationType.PET)
                 .build()
         );
@@ -79,7 +79,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(petName, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
                 .build()
@@ -105,7 +105,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(petName, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
                 .build()
@@ -128,7 +128,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(null, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
                 .build()
@@ -167,7 +167,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(petName, "50 killcount"))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
                 .build()
@@ -205,7 +205,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(petName, "50 killcount"))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
                 .build()
@@ -227,7 +227,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(null, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .type(NotificationType.PET)
                 .build()
         );
@@ -272,7 +272,7 @@ class PetNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .extra(new PetNotificationData(null, null))
-                .text(PLAYER_NAME + " got a pet")
+                .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .type(NotificationType.PET)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/PlayerKillNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PlayerKillNotifierTest.java
@@ -87,7 +87,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has PK'd %s", PLAYER_NAME, TARGET))
+                .text(buildTemplate(String.format("%s has PK'd %s", PLAYER_NAME, TARGET)))
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, damage))
@@ -110,7 +110,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has PK'd %s", PLAYER_NAME, TARGET))
+                .text(buildTemplate(String.format("%s has PK'd %s", PLAYER_NAME, TARGET)))
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, 12))
@@ -137,7 +137,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has PK'd %s", PLAYER_NAME, TARGET))
+                .text(buildTemplate(String.format("%s has PK'd %s", PLAYER_NAME, TARGET)))
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, damage))

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.QuestNotificationData;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.events.WidgetLoaded;
@@ -59,7 +61,12 @@ class QuestNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(PLAYER_NAME + " has completed: Dragon Slayer I"))
+                .text(
+                    Template.builder()
+                        .template(PLAYER_NAME + " has completed: {{quest}}")
+                        .replacement("{{quest}}", Replacements.ofWiki("Dragon Slayer I"))
+                        .build()
+                )
                 .extra(new QuestNotificationData("Dragon Slayer I", 22, 156, 44, 293))
                 .type(NotificationType.QUEST)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -59,7 +59,7 @@ class QuestNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(PLAYER_NAME + " has completed: Dragon Slayer I")
+                .text(buildTemplate(PLAYER_NAME + " has completed: Dragon Slayer I"))
                 .extra(new QuestNotificationData("Dragon Slayer I", 22, 156, 44, 293))
                 .type(NotificationType.QUEST)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -43,7 +43,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "1 TzTok-Jad", 10, 100))
+                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "1 TzTok-Jad", 10, 100)))
                 .extra(new SlayerNotificationData("1 TzTok-Jad", "100", "10"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -63,7 +63,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed: %s, getting %s points for a total %s tasks completed", PLAYER_NAME, "245 Cave Kraken", "1,000", "1,000"))
+                .text(buildTemplate(String.format("%s has completed: %s, getting %s points for a total %s tasks completed", PLAYER_NAME, "245 Cave Kraken", "1,000", "1,000")))
                 .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -82,7 +82,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "50 Cave Kraken", 10, 150))
+                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "50 Cave Kraken", 10, 150)))
                 .extra(new SlayerNotificationData("50 Cave Kraken", "150", "10"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -101,7 +101,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "36 Barrows brothers", 20, 881))
+                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "36 Barrows brothers", 20, 881)))
                 .extra(new SlayerNotificationData("36 Barrows brothers", "881", "20"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -120,7 +120,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "11 Chaos Elemental", 15, 242))
+                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "11 Chaos Elemental", 15, 242)))
                 .extra(new SlayerNotificationData("11 Chaos Elemental", "242", "15"))
                 .type(NotificationType.SLAYER)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.SlayerNotificationData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +45,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "1 TzTok-Jad", 10, 100)))
+                .text(buildTemplate(1, "TzTok-Jad", 10, 100))
                 .extra(new SlayerNotificationData("1 TzTok-Jad", "100", "10"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -63,7 +65,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed: %s, getting %s points for a total %s tasks completed", PLAYER_NAME, "245 Cave Kraken", "1,000", "1,000")))
+                .text(buildTemplate(245, "Cave Kraken", "1,000", "1,000"))
                 .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -82,7 +84,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "50 Cave Kraken", 10, 150)))
+                .text(buildTemplate(50, "Cave Kraken", 10, 150))
                 .extra(new SlayerNotificationData("50 Cave Kraken", "150", "10"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -101,7 +103,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "36 Barrows brothers", 20, 881)))
+                .text(buildTemplate(36, "Barrows brothers", 20, 881))
                 .extra(new SlayerNotificationData("36 Barrows brothers", "881", "20"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -120,7 +122,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has completed: %s, getting %d points for a total %d tasks completed", PLAYER_NAME, "11 Chaos Elemental", 15, 242)))
+                .text(buildTemplate(11, "Chaos Elemental", 15, 242))
                 .extra(new SlayerNotificationData("11 Chaos Elemental", "242", "15"))
                 .type(NotificationType.SLAYER)
                 .build()
@@ -150,4 +152,11 @@ class SlayerNotifierTest extends MockedNotifierTest {
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 
+    private static Template buildTemplate(int count, String monster, Object points, Object completed) {
+        String task = String.format("%d %s", count, monster);
+        return Template.builder()
+            .template(String.format("%s has completed: {{task}}, getting %s points for a total %s tasks completed", PLAYER_NAME, points, completed))
+            .replacement("{{task}}", Replacements.ofWiki(task, monster))
+            .build();
+    }
 }

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -69,7 +69,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest))
+                .text(buildTemplate(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest)))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
                 .build()
@@ -129,7 +129,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest))
+                .text(buildTemplate(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest)))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
                 .build()

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -3,6 +3,8 @@ package dinkplugin.notifiers;
 import com.google.inject.testing.fieldbinder.Bind;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
+import dinkplugin.message.templating.Replacements;
+import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.SpeedrunNotificationData;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
@@ -69,7 +71,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest)))
+                .text(buildTemplate(QUEST_NAME, latest))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
                 .build()
@@ -129,7 +131,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has beat their PB of %s with a time of %s", PLAYER_NAME, QUEST_NAME, latest)))
+                .text(buildTemplate(QUEST_NAME, latest))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
                 .build()
@@ -160,4 +162,10 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         return event;
     }
 
+    private static Template buildTemplate(String quest, String time) {
+        return Template.builder()
+            .template(String.format("%s has beat their PB of {{quest}} with a time of %s", PLAYER_NAME, time))
+            .replacement("{{quest}}", Replacements.ofWiki(quest))
+            .build();
+    }
 }


### PR DESCRIPTION
Closes #241

Notifiers without wiki links:
* Player Kill (for another PR as it will use player lookup service rather than wiki)
* Pet (because `%PET%` is not currently a pattern since obtaining the name can be unreliable)
* Group Storage (because diff codeblock prevents item links)

## Examples

### Achievement Diary
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/ddf6fa60-bb0a-4620-b899-49fb8214e904)

* https://oldschool.runescape.wiki/w/Special:Search?search=Karamja%20Diary

### BA Gambles
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/85243ca9-06b1-40fb-8a55-efd7e6230106)

* https://oldschool.runescape.wiki/w/Special:Search?search=Dragon%20chainbody

### Clue
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/2974f318-8ea4-4d58-b6d1-ebe58f19db3c)

* https://oldschool.runescape.wiki/w/Special:Search?search=Clue%20scroll%20(medium)
* https://oldschool.runescape.wiki/w/Special:Search?search=Ruby

### Collection
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/ae7ad0c9-ccbd-4fd3-9622-b42b13037254)

* https://oldschool.runescape.wiki/w/Special:Search?search=Seercull

### Combat Task
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/4b4b11d9-171c-42e3-8d1f-7d3f78586887)

* https://oldschool.runescape.wiki/w/Special:Search?search=No%20Pressure

### Death
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/ff17397d-20cc-4946-b7fd-c4532b13cadb)

* https://oldschool.runescape.wiki/w/Special:Search?search=Guard

### Level
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/97a7a82b-41a2-4524-a7bb-6c2870192e84)

* https://oldschool.runescape.wiki/w/Special:Search?search=Hitpoints
* https://oldschool.runescape.wiki/w/Special:Search?search=Combat%20level

### Loot
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/49f7186f-7f03-4ba6-8594-0c7fb52c6e05)

* https://oldschool.runescape.wiki/w/Special:Search?search=Ruby
* https://oldschool.runescape.wiki/w/Special:Search?search=Opal

### Kill Count
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/a5c1b550-e7d8-4310-a743-5cf4d0d26e39)

* https://oldschool.runescape.wiki/w/Special:Search?search=Tombs%20of%20Amascut:%20Expert%20Mode

### Quest
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/5a1f5ce6-c0e4-4034-b65a-272ee6dd4c17)

* https://oldschool.runescape.wiki/w/Special:Search?search=Dragon%20Slayer%20I

### Slayer
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/aa862b9a-cd11-4f14-9210-00fc7aa04785)

* https://oldschool.runescape.wiki/w/Special:Search?search=Chaos%20Elemental

### Speedrun
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/a7515fc3-1ac3-4f04-b6b4-86d6d73ebb59)

* https://oldschool.runescape.wiki/w/Special:Search?search=Cook%27s%20Assistant
