### PR TITLE
refactor: split slayer task into monster and kc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Minor: Add setting to exclude group name from GIM shared storage notifications. (#247)
-- Minor: Include relevant wiki links in rich embed content. (#243)
+- Minor: Include relevant wiki links in rich embed content. (#243, #248)
 
 ## 1.5.1
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ Lastly, Dink makes exceptions for Inferno and TzHaar Fight Cave; deaths in these
   "extra": {
     "slayerTask": "Slayer task name",
     "slayerCompleted": "30",
-    "slayerPoints": "30"
+    "slayerPoints": "15",
+    "incrementalKills": 135,
+    "monster": "Kalphite"
   },
   "type": "SLAYER"
 }

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Lastly, Dink makes exceptions for Inferno and TzHaar Fight Cave; deaths in these
     "slayerTask": "Slayer task name",
     "slayerCompleted": "30",
     "slayerPoints": "15",
-    "incrementalKills": 135,
+    "killCount": 135,
     "monster": "Kalphite"
   },
   "type": "SLAYER"

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -118,7 +118,7 @@ public class SlayerNotifier extends BaseNotifier {
 
             createMessage(config.slayerSendImage(), NotificationBody.builder()
                 .text(notifyMessage)
-                .extra(new SlayerNotificationData(task, slayerCompleted, slayerPoints))
+                .extra(new SlayerNotificationData(task, slayerCompleted, slayerPoints, marginalKillCount, monster))
                 .type(NotificationType.SLAYER)
                 .build());
         }

--- a/src/main/java/dinkplugin/notifiers/data/SlayerNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/SlayerNotificationData.java
@@ -19,7 +19,7 @@ public class SlayerNotificationData extends NotificationData {
     String slayerPoints;
 
     @Nullable // if jagex changes format of slayerTask
-    Integer incrementalKills;
+    Integer killCount;
 
     @Nullable // if jagex changes format of slayerTask
     String monster;

--- a/src/main/java/dinkplugin/notifiers/data/SlayerNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/SlayerNotificationData.java
@@ -2,11 +2,26 @@ package dinkplugin.notifiers.data;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class SlayerNotificationData extends NotificationData {
+
+    @NotNull
     String slayerTask;
+
+    @NotNull
     String slayerCompleted;
+
+    @NotNull
     String slayerPoints;
+
+    @Nullable // if jagex changes format of slayerTask
+    Integer incrementalKills;
+
+    @Nullable // if jagex changes format of slayerTask
+    String monster;
+
 }

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -46,7 +46,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(1, "TzTok-Jad", 10, 100))
-                .extra(new SlayerNotificationData("1 TzTok-Jad", "100", "10"))
+                .extra(new SlayerNotificationData("1 TzTok-Jad", "100", "10", 1, "TzTok-Jad"))
                 .type(NotificationType.SLAYER)
                 .build()
         );
@@ -66,7 +66,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(245, "Cave Kraken", "1,000", "1,000"))
-                .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000"))
+                .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000", 245, "Cave Kraken"))
                 .type(NotificationType.SLAYER)
                 .build()
         );
@@ -85,7 +85,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(50, "Cave Kraken", 10, 150))
-                .extra(new SlayerNotificationData("50 Cave Kraken", "150", "10"))
+                .extra(new SlayerNotificationData("50 Cave Kraken", "150", "10", 50, "Cave Kraken"))
                 .type(NotificationType.SLAYER)
                 .build()
         );
@@ -104,7 +104,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(36, "Barrows brothers", 20, 881))
-                .extra(new SlayerNotificationData("36 Barrows brothers", "881", "20"))
+                .extra(new SlayerNotificationData("36 Barrows brothers", "881", "20", 36, "Barrows brothers"))
                 .type(NotificationType.SLAYER)
                 .build()
         );
@@ -123,7 +123,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(11, "Chaos Elemental", 15, 242))
-                .extra(new SlayerNotificationData("11 Chaos Elemental", "242", "15"))
+                .extra(new SlayerNotificationData("11 Chaos Elemental", "242", "15", 11, "Chaos Elemental"))
                 .type(NotificationType.SLAYER)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -153,10 +153,9 @@ class SlayerNotifierTest extends MockedNotifierTest {
     }
 
     private static Template buildTemplate(int count, String monster, Object points, Object completed) {
-        String task = String.format("%d %s", count, monster);
         return Template.builder()
-            .template(String.format("%s has completed: {{task}}, getting %s points for a total %s tasks completed", PLAYER_NAME, points, completed))
-            .replacement("{{task}}", Replacements.ofWiki(task, monster))
+            .template(String.format("%s has completed: %d {{monster}}, getting %s points for a total %s tasks completed", PLAYER_NAME, count, points, completed))
+            .replacement("{{monster}}", Replacements.ofWiki(monster))
             .build();
     }
 }


### PR DESCRIPTION
Follow-up from https://github.com/pajlads/DinkPlugin/pull/243#pullrequestreview-1440199599

![image](https://github.com/pajlads/DinkPlugin/assets/8106344/d1c8ab68-f2d8-4532-8090-08441ea8f170)

* https://oldschool.runescape.wiki/w/Special:Search?search=Cave%20Kraken
