### PR TITLE
fix: ensure LevelNotifier#initLevels is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Add setting to exclude group name from GIM shared storage notifications. (#247)
 - Minor: Include relevant wiki links in rich embed content. (#243)
+- Bugfix: Avoid combat level notifications that don't conform to the configured interval. (#250)
 
 ## 1.5.1
 

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -14,6 +14,7 @@ import dinkplugin.util.BlockingClientThread;
 import dinkplugin.util.BlockingExecutor;
 import dinkplugin.util.TestImageUtil;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
@@ -104,6 +105,7 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(client.getVarbitValue(Varbits.ACCOUNT_TYPE)).thenReturn(AccountType.GROUP_IRONMAN.ordinal());
         when(client.isPrayerActive(any())).thenReturn(false);
         when(client.getLocalPlayer()).thenReturn(localPlayer);
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(localPlayer.getName()).thenReturn(PLAYER_NAME);
 
         doAnswer(invocation -> {


### PR DESCRIPTION
Previously `initLevels` was only called from `onTick`, but `StatChanged` events initialized the map before the tick event, so `initLevels` wasn't called. This wasn't problematic until we added combat level initialization at the end of `initLevels` (so combat level could be initialized with incomplete level data from the initial StatChanged events). This bug came to light after #240, as it became possible to trigger combat level notifications that don't match the specified interval (due to jumping over a number that is a multiple of the interval).

This PR calls `initLevels` upon the initial `StatChanged` events after login.

In addition, we ensure level initialization only occurs on the client thread (since `initLevels` is called on plugin start up, which can be on the swing thread). As a result, `ConcurrentHashMap` can be replaced with `HashMap`.

Technically `initLevels` is called multiple times in a single tick now, but this can be "fixed" in a follow-up PR
