### PR TITLE
Release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.5.2
+
 - Minor: Include link to killed player profile in PK notifier. (#246)
 - Minor: Add setting to exclude group name from GIM shared storage notifications. (#247)
 - Minor: Include relevant wiki links in rich embed content. (#243, #248)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.5.1"
+version = "1.5.2"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.5.2 augments rich embeds with relevant wiki links and fixes some bugs. In particular, death notifications feature improved kept/lost classification of stackable items, and level notifications are more reliable for combat levels.
