### PR TITLE
(docs): re-implement info about for generating a discord webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Minor: Include link to killed player profile in PK notifier. (#246)
 - Minor: Add setting to exclude group name from GIM shared storage notifications. (#247)
 - Minor: Include relevant wiki links in rich embed content. (#243, #248)
+- Minor: Re-implemented README info for generating a Discord webhook. (#256)
 - Bugfix: Ignore notifications from new beta worlds. (#253)
 - Bugfix: Avoid combat level notifications that don't conform to the configured interval. (#250, #251)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ This project was forked from UniversalDiscordNotifier, but has more features, re
 
 Have a suggestion (e.g., new notifier, additional data), bug report (as rare as it may be), or question? Let us know on our [issue tracker](https://github.com/pajlads/DinkPlugin/issues)!
 
+
+## Basic Setup
+
+To use this plugin a webhook is required, you can obtain one from Discord with the following steps:
+<sub>If you already have a link, skip to step 4.</sub>
+
+1. Click the sever name top-left and select `Server Settings`.
+2. Select the `Integrations` tab on the left side and click `Create/View Webhook(s)`.
+3. Click the newly created or existing webhook, and select `Copy Webhook URL`.
+4. Paste the copied link into the `Primary Webhook URLs` box.
+5. (Optional): If you would like only certain notifications sent to the discord in question, you can paste the link into each box in the `Webhook Overrides` section.
+
 ## Notifiers
 
 - [Death](#death): Send a webhook message upon dying (with special configuration for PK deaths)


### PR DESCRIPTION
It got axed all the way back in https://github.com/pajlads/DinkPlugin/commit/41067dbce2593e09ccc2023aa7057e43ddc385b6 but someone came into the Runelite discord asking how to sync his discord account to Dink, so this info should probably be somewhere.


Also apparently I had a stroke and forgot how to use markdown so if there's something better than `sub` let me know