### PR TITLE
perf: speed up template evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Optimize notification templating engine performance. (#258)
+
 ## 1.5.2
 
 - Minor: Include link to killed player profile in PK notifier. (#246)

--- a/src/main/java/dinkplugin/message/templating/Template.java
+++ b/src/main/java/dinkplugin/message/templating/Template.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -17,13 +18,44 @@ public class Template implements Evaluable {
     @Singular
     Map<String, Evaluable> replacements;
 
+    @Nullable
+    String replacementBoundary; // e.g., "%"
+
     @Override
     public String evaluate(boolean rich) {
+        if (replacementBoundary != null) {
+            return evaluateFast(rich);
+        }
+        return evaluateSlow(rich);
+    }
+
+    private String evaluateSlow(boolean rich) {
         String message = template;
         for (Map.Entry<String, Evaluable> e : replacements.entrySet()) {
             message = message.replace(e.getKey(), e.getValue().evaluate(rich));
         }
         return message;
+    }
+
+    private String evaluateFast(boolean rich) {
+        StringBuilder message = new StringBuilder(template);
+        int i = message.indexOf(replacementBoundary);
+        while (i != -1) {
+            int next = message.indexOf(replacementBoundary, i + 1);
+            if (next < 0) break;
+
+            int endExclusive = next + 1;
+            String key = message.substring(i, endExclusive);
+            Evaluable replacement = replacements.get(key);
+            if (replacement != null) {
+                String evaluated = replacement.evaluate(rich);
+                message.replace(i, endExclusive, evaluated);
+                i = endExclusive + evaluated.length() - key.length();
+            } else {
+                i = next;
+            }
+        }
+        return message.toString();
     }
 
     @Override

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -117,6 +117,7 @@ public class ClueNotifier extends BaseNotifier {
             boolean screenshot = config.clueSendImage() && totalPrice.get() >= config.clueImageMinValue();
             Template notifyMessage = Template.builder()
                 .template(config.clueNotifyMessage())
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
                 .replacement("%CLUE%", Replacements.ofWiki(clueType, "Clue scroll (" + clueType + ")"))
                 .replacement("%COUNT%", Replacements.ofText(clueCount))

--- a/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CollectionNotifier.java
@@ -111,6 +111,7 @@ public class CollectionNotifier extends BaseNotifier {
     private void handleNotify(String itemName) {
         Template notifyMessage = Template.builder()
             .template(config.collectionNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .replacement("%ITEM%", Replacements.ofWiki(itemName))
             .build();

--- a/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/CombatTaskNotifier.java
@@ -102,6 +102,7 @@ public class CombatTaskNotifier extends BaseNotifier {
             String player = Utils.getPlayerName(client);
             Template message = Template.builder()
                 .template(crossedThreshold ? config.combatTaskUnlockMessage() : config.combatTaskMessage())
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText(player))
                 .replacement("%TIER%", Replacements.ofText(tier.toString()))
                 .replacement("%TASK%", Replacements.ofWiki(task))

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -196,6 +196,7 @@ public class DeathNotifier extends BaseNotifier {
 
         Template.TemplateBuilder builder = Template.builder()
             .template(template)
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .replacement("%VALUELOST%", Replacements.ofText(String.valueOf(losePrice)));
         if (pvp) {

--- a/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DiaryNotifier.java
@@ -152,6 +152,7 @@ public class DiaryNotifier extends BaseNotifier {
         String player = Utils.getPlayerName(client);
         Template message = Template.builder()
             .template(config.diaryNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(player))
             .replacement("%DIFFICULTY%", Replacements.ofText(difficulty.toString()))
             .replacement("%AREA%", Replacements.ofWiki(area, area + " Diary"))

--- a/src/main/java/dinkplugin/notifiers/GambleNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GambleNotifier.java
@@ -74,6 +74,7 @@ public class GambleNotifier extends BaseNotifier {
         List<SerializedItemStack> items = serializeItems(data);
         Template message = Template.builder()
             .template(messageFormat)
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(player))
             .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.gambleCount)))
             .replacement("%LOOT%", lootSummary(items))

--- a/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
@@ -178,8 +178,9 @@ public class GroupStorageNotifier extends BaseNotifier {
             new String[] { playerName, depositString, withdrawalString }
         );
         Template formattedText = Template.builder()
-            .template("{{s}}")
-            .replacement("{{s}}", Replacements.ofBlock("diff", content))
+            .template("$s$")
+            .replacementBoundary("$")
+            .replacement("$s$", Replacements.ofBlock("diff", content))
             .build();
 
         // Populate metadata

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -109,6 +109,7 @@ public class KillCountNotifier extends BaseNotifier {
         String time = TimeUtils.format(data.getTime(), TimeUtils.isPreciseTiming(client));
         Template content = Template.builder()
             .template(isPb ? config.killCountBestTimeMessage() : config.killCountMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(player))
             .replacement("%BOSS%", Replacements.ofWiki(data.getBoss()))
             .replacement("%COUNT%", Replacements.ofText(String.valueOf(data.getCount())))

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -224,6 +224,7 @@ public class LevelNotifier extends BaseNotifier {
         // Populate message template
         Template fullNotification = Template.builder()
             .template(config.levelNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .replacement("%SKILL%", skillMessage.build())
             .build();

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -141,6 +141,7 @@ public class LootNotifier extends BaseNotifier {
             boolean screenshot = config.lootSendImage() && totalStackValue >= config.lootImageMinValue();
             Template notifyMessage = Template.builder()
                 .template(config.lootNotifyMessage())
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
                 .replacement("%LOOT%", lootMessage.build())
                 .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalStackValue)))

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -131,6 +131,7 @@ public class PetNotifier extends BaseNotifier {
     private void handleNotify() {
         Template notifyMessage = Template.builder()
             .template(config.petNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .build();
 

--- a/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PlayerKillNotifier.java
@@ -118,6 +118,7 @@ public class PlayerKillNotifier extends BaseNotifier {
         String localPlayer = client.getLocalPlayer().getName();
         Template message = Template.builder()
             .template(config.pkNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(localPlayer))
             .replacement("%TARGET%", Replacements.ofLink(target.getName(), config.playerLookupService().getPlayerUrl(target.getName())))
             .build();

--- a/src/main/java/dinkplugin/notifiers/QuestNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/QuestNotifier.java
@@ -73,6 +73,7 @@ public class QuestNotifier extends BaseNotifier {
 
         Template notifyMessage = Template.builder()
             .template(config.questNotifyMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .replacement("%QUEST%", Replacements.ofWiki(parsed))
             .build();

--- a/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SlayerNotifier.java
@@ -110,6 +110,7 @@ public class SlayerNotifier extends BaseNotifier {
 
             Template notifyMessage = Template.builder()
                 .template(config.slayerNotifyMessage())
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
                 .replacement("%TASK%", buildTask(task, monster, marginalKillCount))
                 .replacement("%TASKCOUNT%", Replacements.ofText(slayerCompleted))

--- a/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/SpeedrunNotifier.java
@@ -58,6 +58,7 @@ public class SpeedrunNotifier extends BaseNotifier {
         // pb or notifying on non-pb; take the right string and format placeholders
         Template notifyMessage = Template.builder()
             .template(isPb ? config.speedrunPBMessage() : config.speedrunMessage())
+            .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
             .replacement("%QUEST%", Replacements.ofWiki(questName))
             .replacement("%TIME%", Replacements.ofText(duration))

--- a/src/test/java/dinkplugin/message/templating/TemplateTest.java
+++ b/src/test/java/dinkplugin/message/templating/TemplateTest.java
@@ -18,6 +18,18 @@ class TemplateTest {
     }
 
     @Test
+    void noReplacementsFast() {
+        assertEquals(
+            "Hello world!",
+            Template.builder()
+                .template("Hello world!")
+                .replacementBoundary("%")
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
     void unusedReplacements() {
         assertEquals(
             "Hello world!",
@@ -30,11 +42,38 @@ class TemplateTest {
     }
 
     @Test
+    void unusedReplacementsFast() {
+        assertEquals(
+            "Hello world!",
+            Template.builder()
+                .template("Hello world!")
+                .replacementBoundary("%")
+                .replacement("%PLANET%", Replacements.ofText("Earth"))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
     void withReplacements() {
         assertEquals(
             "dank dank has killed Monk",
             Template.builder()
                 .template("%USERNAME% has killed %TARGET%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(false)
+        );
+    }
+
+    @Test
+    void withReplacementsFast() {
+        assertEquals(
+            "dank dank has killed Monk",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText("dank dank"))
                 .replacement("%TARGET%", Replacements.ofWiki("Monk"))
                 .build()
@@ -56,11 +95,38 @@ class TemplateTest {
     }
 
     @Test
+    void withRichReplacementsFast() {
+        assertEquals(
+            "dank dank has killed [Monk](https://oldschool.runescape.wiki/w/Special:Search?search=Monk)",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacementBoundary("%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
     void missingReplacements() {
         assertEquals(
             "%USERNAME% has killed Monk",
             Template.builder()
                 .template("%USERNAME% has killed %TARGET%")
+                .replacement("%TARGET%", Replacements.ofWiki("Monk"))
+                .build()
+                .evaluate(false)
+        );
+    }
+
+    @Test
+    void missingReplacementsFast() {
+        assertEquals(
+            "%USERNAME% has killed Monk",
+            Template.builder()
+                .template("%USERNAME% has killed %TARGET%")
+                .replacementBoundary("%")
                 .replacement("%TARGET%", Replacements.ofWiki("Monk"))
                 .build()
                 .evaluate(false)
@@ -80,11 +146,40 @@ class TemplateTest {
         );
     }
 
+    @Test
+    void withRichLinkFast() {
+        assertEquals(
+            "dank dank has pk'd [Forsen](https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=Forsen)",
+            Template.builder()
+                .template("%USERNAME% has pk'd %TARGET%")
+                .replacementBoundary("%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofLink("Forsen", "https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=Forsen"))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
     void withRichNullLink() {
         assertEquals(
             "dank dank has pk'd Forsen",
             Template.builder()
                 .template("%USERNAME% has pk'd %TARGET%")
+                .replacement("%USERNAME%", Replacements.ofText("dank dank"))
+                .replacement("%TARGET%", Replacements.ofLink("Forsen", null))
+                .build()
+                .evaluate(true)
+        );
+    }
+
+    @Test
+    void withRichNullLinkFast() {
+        assertEquals(
+            "dank dank has pk'd Forsen",
+            Template.builder()
+                .template("%USERNAME% has pk'd %TARGET%")
+                .replacementBoundary("%")
                 .replacement("%USERNAME%", Replacements.ofText("dank dank"))
                 .replacement("%TARGET%", Replacements.ofLink("Forsen", null))
                 .build()


### PR DESCRIPTION
Creates $O(n)$ fast path instead of $O(n \cdot m)$ for `Template#evaluate`