### PR TITLE
feat: level interval override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Adds option to announce every level-up past a certain level. (#265)
 - Bugfix: Increase level notifier initialization delay, as it sometimes occurred too early causing incorrect levelup notifications to trigger. (#264)
 - Dev: Update gradle wrapper to v8.2, which includes path traversal fixes. (#263)
 - Dev: Optimize notification templating engine performance. (#258)

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -593,7 +593,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "levelIntervalOverride",
         name = "Interval Override Level",
-        description = "The minimum level after which all level ups send a notification.<br/>" +
+        description = "All level ups starting from this override level send a notification, disregarding the configured Notify Interval.<br/>" +
             "Disabled when set to 0",
         position = 26,
         section = levelSection

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -591,12 +591,23 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "levelIntervalOverride",
+        name = "Interval Override Level",
+        description = "The minimum level after which all level ups send a notification.",
+        position = 26,
+        section = levelSection
+    )
+    default int levelIntervalOverride() {
+        return 0;
+    }
+
+    @ConfigItem(
         keyName = "levelNotifMessage",
         name = "Notification Message",
         description = "The message to be sent through the webhook.<br/>" +
             "Use %USERNAME% to insert your username<br/>" +
             "Use %SKILL% to insert the levelled skill(s)",
-        position = 26,
+        position = 27,
         section = levelSection
     )
     default String levelNotifyMessage() {

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -593,7 +593,8 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "levelIntervalOverride",
         name = "Interval Override Level",
-        description = "The minimum level after which all level ups send a notification.",
+        description = "The minimum level after which all level ups send a notification.<br/>" +
+            "Disabled when set to 0",
         position = 26,
         section = levelSection
     )

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -249,6 +249,10 @@ public class LevelNotifier extends BaseNotifier {
         if (interval <= 1 || level == MAX_REAL_LEVEL)
             return true;
 
+        int intervalOverride = config.levelIntervalOverride();
+        if (intervalOverride > 0 && level >= intervalOverride) {
+            return true;
+        }
         // Check levels in (previous, current] for divisibility by interval
         // Allows for firing notification if jumping over a level that would've notified
         int remainder = level % interval;


### PR DESCRIPTION
Adds a setting to announce all level-ups past a certain point. i.e. if you had an interval of 5, a minimum skill level of 80, and an override of 95, levels 80, 85, 90, 95, 96, 97, 98, 99 would be announced.
