### PR TITLE
fix(build): allow building plugin with jdk17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Adds option to announce every level-up past a certain level. (#265)
 - Bugfix: Increase level notifier initialization delay, as it sometimes occurred too early causing incorrect levelup notifications to trigger. (#264)
+- Dev: Avoid compiler exception when building the plugin with JDK 17+. (#267)
 - Dev: Update gradle wrapper to v8.2, which includes path traversal fixes. (#263)
 - Dev: Optimize notification templating engine performance. (#258)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,8 +11,12 @@ repositories {
 }
 
 dependencies {
-    // old version and annotation processor approach due to runelite plugin hub verification restrictions
-    val lombokVersion = "1.18.20"
+    val lombokVersion = if (JavaVersion.current() >= JavaVersion.VERSION_17) {
+        "1.18.28" // JDK17 support was added in 1.18.22, but we can utilize latest since plugin-hub runs JDK11
+    } else {
+        "1.18.20" // Most recent version (only supports up to JDK16) that is verified by runelite
+    }
+    // old annotation processor approach due to runelite plugin hub verification restrictions
     compileOnly(group = "org.projectlombok", name = "lombok", version = lombokVersion)
     annotationProcessor(group = "org.projectlombok", name = "lombok", version = lombokVersion)
     testCompileOnly(group = "org.projectlombok", name = "lombok", version = lombokVersion)


### PR DESCRIPTION
Attempting to build the plugin with the latest LTS JDK (17) yields the following compiler exception due to the outdated lombok version mandated by plugin hub restrictions:
```
An exception has occurred in the compiler (17). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot read field "bindingsWhenTrue" because "currentBindings" is null
[stacktrace omitted]
```

Now we use the latest lombok version if JDK 17+ is detected (won't affect plugin hub as they use 11)