### PR TITLE
perf(level): avoid binary search when unnecessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Adds option to announce every level-up past a certain level. (#265)
 - Bugfix: Increase level notifier initialization delay, as it sometimes occurred too early causing incorrect levelup notifications to trigger. (#264)
+- Dev: Optimize skill level initialization algorithm. (#269)
 - Dev: Remove references to deprecated Skill.OVERALL enum value. (#266)
 - Dev: Avoid compiler exception when building the plugin with JDK 17+. (#267)
 - Dev: Update gradle wrapper to v8.2, which includes path traversal fixes. (#263)

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -60,8 +60,12 @@ public class LevelNotifier extends BaseNotifier {
                 return false; // still need to wait more ticks
 
             for (Skill skill : Skill.values()) {
-                // uses log(n) operation to support virtual levels
-                currentLevels.put(skill.getName(), Experience.getLevelForXp(client.getSkillExperience(skill)));
+                int level = client.getRealSkillLevel(skill); // O(1)
+                if (level >= MAX_REAL_LEVEL) {
+                    // uses log(n) operation to support virtual levels
+                    level = Experience.getLevelForXp(client.getSkillExperience(skill));
+                }
+                currentLevels.put(skill.getName(), level);
             }
             currentLevels.put(COMBAT_NAME, calculateCombatLevel());
             log.debug("Initialized current skill levels: {}", currentLevels);


### PR DESCRIPTION
Optimization: when skill level is <99, don't need to binary search for virtual level by experience

Can convert level initialization from $O(n \cdot log(m))$ to just $O(n)$ in the best case
