### PR TITLE
Release v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.5.3
+
 - Minor: Adds option to announce every level-up past a certain level. (#265)
 - Bugfix: Increase level notifier initialization delay, as it sometimes occurred too early causing incorrect levelup notifications to trigger. (#264)
 - Dev: Optimize skill level initialization algorithm. (#269)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.5.2"
+version = "1.5.3"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Small bump for level bugfix & removal of `Skill.OVERALL`
