### PR TITLE
feat(ge): notify new completions upon login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Major: Add notifier for when items are bought or sold on the Grand Exchange. (#275)
+- Major: Add notifier for when items are bought or sold on the Grand Exchange. (#275, #277)
 - Minor: Fire level notification upon reaching max skill experience of 200M. (#273)
 - Minor: Include clan name in notificiation metadata. (#274)
 - Dev: Update gradle wrapper to v8.2.1 patch version. (#276)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -194,7 +194,7 @@ public class DinkPlugin extends Plugin {
         }
     }
 
-    @Subscribe
+    @Subscribe(priority = 1) // run before the base GE plugin
     public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged event) {
         grandExchangeNotifier.onOfferChange(event.getSlot(), event.getOffer());
     }

--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -126,7 +126,8 @@ public class GrandExchangeNotifier extends BaseNotifier {
             if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD)
                 return false;
 
-            // require GE plugin to be enabled to be sure observed trades are written to config
+            // require GE plugin to be enabled so that observed trades are written to config
+            // however: not bullet-proof since GE plugin could've been disabled during the initial trade completion
             if ("false".equals(configManager.getConfiguration(RuneLiteConfig.GROUP_NAME, RL_GE_PLUGIN_NAME)))
                 return false;
 

--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -1,6 +1,8 @@
 package dinkplugin.notifiers;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import dinkplugin.message.Embed;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -9,6 +11,7 @@ import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GrandExchangeNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
 import dinkplugin.util.ItemUtils;
+import dinkplugin.util.SerializedOffer;
 import dinkplugin.util.Utils;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +22,10 @@ import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.grandexchange.GrandExchangePlugin;
 
 import javax.inject.Inject;
 import java.time.Duration;
@@ -28,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,8 +42,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class GrandExchangeNotifier extends BaseNotifier {
     private static final Set<Integer> TAX_EXEMPT_ITEMS;
     private static final int LOGIN_DELAY = 2;
+    private static final String RL_GE_PLUGIN_NAME = GrandExchangePlugin.class.getSimpleName().toLowerCase();
     private final AtomicInteger initTicks = new AtomicInteger();
     private final Map<Integer, Instant> progressNotificationTimeBySlot = new HashMap<>();
+
+    @Inject
+    private Gson gson;
+
+    @Inject
+    private ConfigManager configManager;
 
     @Inject
     private ItemManager itemManager;
@@ -106,8 +120,20 @@ public class GrandExchangeNotifier extends BaseNotifier {
     }
 
     private boolean shouldNotify(int slot, GrandExchangeOffer offer) {
-        if (initTicks.get() > 0)
-            return false;
+        // On login, ignore updates if they aren't completions that haven't been observed before
+        if (initTicks.get() > 0) {
+            // check if offer is a completion
+            if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD)
+                return false;
+
+            // require GE plugin to be enabled to be sure observed trades are written to config
+            if ("false".equals(configManager.getConfiguration(RuneLiteConfig.GROUP_NAME, RL_GE_PLUGIN_NAME)))
+                return false;
+
+            // check whether the completion has already been observed
+            if (getSavedOffer(slot).filter(saved -> saved.equals(offer)).isPresent())
+                return false;
+        }
 
         if (!isEnabled())
             return false;
@@ -155,6 +181,18 @@ public class GrandExchangeNotifier extends BaseNotifier {
             default:
                 return false;
         }
+    }
+
+    private Optional<SerializedOffer> getSavedOffer(int slot) {
+        return Optional.ofNullable(configManager.getRSProfileConfiguration("geoffer", String.valueOf(slot)))
+            .map(json -> {
+                try {
+                    return gson.fromJson(json, SerializedOffer.class);
+                } catch (JsonSyntaxException e) {
+                    log.warn("Failed to read saved GE offer", e);
+                    return null;
+                }
+            });
     }
 
     public static String getHumanStatus(GrandExchangeOfferState state) {

--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -120,7 +120,8 @@ public class GrandExchangeNotifier extends BaseNotifier {
     }
 
     private boolean shouldNotify(int slot, GrandExchangeOffer offer) {
-        // On login, ignore updates if they aren't completions that haven't been observed before
+        // During login, we only care about offers that have been completed, and that were *not* observed by the RuneLite GE plugin
+        // This makes sure we don't fire any duplicate notifications for offers that were finished while we were online
         if (initTicks.get() > 0) {
             // check if offer is a completion
             if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD)

--- a/src/main/java/dinkplugin/util/SerializedOffer.java
+++ b/src/main/java/dinkplugin/util/SerializedOffer.java
@@ -1,0 +1,24 @@
+package dinkplugin.util;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import org.jetbrains.annotations.NotNull;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SerializedOffer {
+    private GrandExchangeOfferState state;
+    private @SerializedName("itemId") int id;
+    private @SerializedName("totalQuantity") int quantity;
+    private int price;
+    private int spent;
+
+    public boolean equals(@NotNull GrandExchangeOffer o) {
+        return state == o.getState() && id == o.getItemId() && quantity == o.getTotalQuantity()
+            && price == o.getPrice() && spent == o.getSpent();
+    }
+}


### PR DESCRIPTION
On login, if a GE offer is complete & hasn't been seen before (according to base GE plugin), then allow notification to be fired (given min value is met).

Follow-up from https://github.com/pajlads/DinkPlugin/pull/275#issuecomment-1628081612

Known edge case: if trade completes (triggering a notification to be fired) while playing with GE plugin disabled, player logs out without collecting the proceeds of the trade, user enables GE plugin, and the user logs back into game, then a second (duplicate) notification will be fired. we could address this by writing trade statuses to the dinkplugin config namespace, but this may be overkill
