### PR TITLE
chore(pet): include new DT2 pet names in notification metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Include new Baron pet name in notification metadata. 
+- Minor: Include new pet names from Desert Treasure II bosses in notification metadata. (#279)
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Include new Baron pet name in notification metadata. 
+
 ## 1.6.0
 
 - Major: Add notifier for when items are bought or sold on the Grand Exchange. (#275, #277)

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -177,6 +177,7 @@ public class PetNotifier extends BaseNotifier {
             "Baby chinchompa",
             "Baby mole",
             "Baron",
+            "Butch",
             "Beaver",
             "Bloodhound",
             "Callisto cub",
@@ -191,6 +192,7 @@ public class PetNotifier extends BaseNotifier {
             "Kalphite princess",
             "Lil' creator",
             "Lil' zik",
+            "Lil'viathan",
             "Little nightmare",
             "Muphin",
             "Nexling",
@@ -212,6 +214,7 @@ public class PetNotifier extends BaseNotifier {
             "Venenatis spiderling",
             "Vet'ion jr.",
             "Vorki",
+            "Wisp",
             "Youngllef"
         );
     }

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -176,6 +176,7 @@ public class PetNotifier extends BaseNotifier {
             "Abyssal protector",
             "Baby chinchompa",
             "Baby mole",
+            "Baron",
             "Beaver",
             "Bloodhound",
             "Callisto cub",


### PR DESCRIPTION
Pet notification is still fired without this PR; this PR just allows us to include `Baron` pet name in notification metadata from the collection log or untradeable drop message, for example.

https://oldschool.runescape.wiki/w/Baron
https://oldschool.runescape.wiki/w/Butch
https://oldschool.runescape.wiki/w/Lil%27viathan
https://oldschool.runescape.wiki/w/Wisp
