### PR TITLE
fix: export webhook overrides for ge, pk, gim bank notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Include new pet names from Desert Treasure II bosses in notification metadata. (#279)
+- Bugfix: Classify webhook overrides for player kill, grand exchange, and group storage notifiers appropriately for config exports. (#284)
 
 ## 1.6.0
 

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -109,7 +110,7 @@ public class SettingsManager {
         });
         webhookConfigKeys = ImmutableSet.<String>builder()
             .add("discordWebhook") // DinkPluginConfig#primaryWebhook
-            .addAll(keysBySection.get(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", "")))
+            .addAll(keysBySection.getOrDefault(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", ""), Collections.emptySet()))
             .build();
     }
 

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -107,7 +107,10 @@ public class SettingsManager {
                 ).add(key);
             }
         });
-        webhookConfigKeys = keysBySection.get(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", ""));
+        webhookConfigKeys = ImmutableSet.<String>builder()
+            .add("discordWebhook") // DinkPluginConfig#primaryWebhook
+            .addAll(keysBySection.get(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", "")))
+            .build();
     }
 
     void onCommand(CommandExecuted event) {

--- a/src/main/java/dinkplugin/util/ConfigUtil.java
+++ b/src/main/java/dinkplugin/util/ConfigUtil.java
@@ -1,6 +1,5 @@
 package dinkplugin.util;
 
-import com.google.common.collect.ImmutableSet;
 import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
@@ -14,7 +13,6 @@ import java.awt.Color;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -22,34 +20,6 @@ import java.util.stream.Stream;
 public class ConfigUtil {
 
     private final Pattern DELIM = Pattern.compile("[,;\\n]");
-
-    /**
-     * Set of our config keys that correspond to webhook URL lists.
-     * <p>
-     * These are used in {@link dinkplugin.SettingsManager} for special logic
-     * to merge the previous value with the new value during config imports.
-     *
-     * @see dinkplugin.DinkPluginConfig
-     */
-    public final Collection<String> WEBHOOK_CONFIG_KEYS = ImmutableSet.of(
-        "discordWebhook",
-        "collectionWebhook",
-        "petWebhook",
-        "levelWebhook",
-        "lootWebhook",
-        "deathWebhook",
-        "slayerWebhook",
-        "questWebhook",
-        "clueWebhook",
-        "speedrunWebhook",
-        "killCountWebhook",
-        "combatTaskWebhook",
-        "diaryWebhook",
-        "gambleWebhook",
-        "pkWebhook",
-        "groupStorageWebhook",
-        "grandExchangeWebhook"
-    );
 
     public Stream<String> readDelimited(String value) {
         if (value == null) return Stream.empty();

--- a/src/main/java/dinkplugin/util/ConfigUtil.java
+++ b/src/main/java/dinkplugin/util/ConfigUtil.java
@@ -45,7 +45,10 @@ public class ConfigUtil {
         "killCountWebhook",
         "combatTaskWebhook",
         "diaryWebhook",
-        "gambleWebhook"
+        "gambleWebhook",
+        "pkWebhook",
+        "groupStorageWebhook",
+        "grandExchangeWebhook"
     );
 
     public Stream<String> readDelimited(String value) {


### PR DESCRIPTION
`pkWebhook`, `groupStorageWebhook`, `grandExchangeWebhook` were not being exported upon `::dinkexport webhooks` (yet *would* be included upon `::dinkexport`)

This PR also loads the webhook config key names dynamically now, so this bug shouldn't happen again when new notifiers are added
