### PR TITLE
fix: allow whisperer loot to trigger notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Include new pet names from Desert Treasure II bosses in notification metadata. (#279)
+- Bugfix: Fire loot notifications for The Whisperer kills. (#286)
 - Bugfix: Classify webhook overrides for player kill, grand exchange, and group storage notifiers appropriately for config exports. (#284)
 
 ## 1.6.0

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -57,7 +57,7 @@ public class LootNotifier extends BaseNotifier {
         NPC npc = event.getNpc();
         int id = npc.getId();
         if (id == NpcID.THE_WHISPERER || id == NpcID.THE_WHISPERER_12205 || id == NpcID.THE_WHISPERER_12206 || id == NpcID.THE_WHISPERER_12207) {
-            // Upstream neglects to fire NpcLootReceived for the whisperer, which they assert is intentional.
+            // Upstream does not fire NpcLootReceived for the whisperer, since they do not hold a reference to the NPC.
             // So, we use LootReceived instead (and return here just in case they change their implementation).
             return;
         }

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -54,6 +54,8 @@ public class LootNotifier extends BaseNotifier {
     }
 
     public void onNpcLootReceived(NpcLootReceived event) {
+        if (!isEnabled()) return;
+
         NPC npc = event.getNpc();
         int id = npc.getId();
         if (id == NpcID.THE_WHISPERER || id == NpcID.THE_WHISPERER_12205 || id == NpcID.THE_WHISPERER_12206 || id == NpcID.THE_WHISPERER_12207) {
@@ -61,9 +63,8 @@ public class LootNotifier extends BaseNotifier {
             // So, we use LootReceived instead (and return here just in case they change their implementation).
             return;
         }
-        if (isEnabled()) {
-            this.handleNotify(event.getItems(), npc.getName(), LootRecordType.NPC);
-        }
+
+        this.handleNotify(event.getItems(), npc.getName(), LootRecordType.NPC);
     }
 
     public void onPlayerLootReceived(PlayerLootReceived event) {

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -12,6 +12,8 @@ import dinkplugin.util.ItemUtils;
 import dinkplugin.util.Utils;
 import dinkplugin.util.WorldUtils;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -52,8 +54,16 @@ public class LootNotifier extends BaseNotifier {
     }
 
     public void onNpcLootReceived(NpcLootReceived event) {
-        if (isEnabled())
-            this.handleNotify(event.getItems(), event.getNpc().getName(), LootRecordType.NPC);
+        NPC npc = event.getNpc();
+        int id = npc.getId();
+        if (id == NpcID.THE_WHISPERER || id == NpcID.THE_WHISPERER_12205 || id == NpcID.THE_WHISPERER_12206 || id == NpcID.THE_WHISPERER_12207) {
+            // Upstream neglects to fire NpcLootReceived for the whisperer, which they assert is intentional.
+            // So, we use LootReceived instead (and return here just in case they change their implementation).
+            return;
+        }
+        if (isEnabled()) {
+            this.handleNotify(event.getItems(), npc.getName(), LootRecordType.NPC);
+        }
     }
 
     public void onPlayerLootReceived(PlayerLootReceived event) {
@@ -74,6 +84,9 @@ public class LootNotifier extends BaseNotifier {
                 return;
             }
 
+            this.handleNotify(lootReceived.getItems(), lootReceived.getName(), lootReceived.getType());
+        } else if (lootReceived.getType() == LootRecordType.NPC && "The Whisperer".equalsIgnoreCase(lootReceived.getName())) {
+            // Special case: upstream fires LootReceived for the whisperer, but not NpcLootReceived
             this.handleNotify(lootReceived.getItems(), lootReceived.getName(), lootReceived.getType());
         }
     }

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -34,7 +34,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 class LootNotifierTest extends MockedNotifierTest {
@@ -84,7 +83,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onNpcLootReceived(event);
 
         // verify notification message
-        verify(messageHandler, times(1)).createMessage(
+        verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -23,6 +23,7 @@ import net.runelite.client.plugins.loottracker.LootReceived;
 import net.runelite.client.util.QuantityFormatter;
 import net.runelite.http.api.loottracker.LootRecordType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
@@ -99,9 +100,8 @@ class LootNotifierTest extends MockedNotifierTest {
         );
     }
 
-    // Ensure abnormal lootReceived npc loot event for The Whisperer boss fires a notification
-    // See https://github.com/pajlads/DinkPlugin/pull/286 for more context
     @Test
+    @DisplayName("Ensure LootReceived event for The Whisperer fires a notification - https://github.com/pajlads/DinkPlugin/pull/286")
     void testNotifyWhisperer() {
         String name = "The Whisperer";
 
@@ -126,10 +126,9 @@ class LootNotifierTest extends MockedNotifierTest {
         );
     }
 
-    // Ensure normal npc loot event for The Whisperer boss doesn't fire a notification
-    // See https://github.com/pajlads/DinkPlugin/pull/286 for more context
     @Test
-    void testNotifyWhispererNPCLootIgnored() {
+    @DisplayName("Ensure NpcLootReceived for The Whisperer doesn't fire a notification - https://github.com/pajlads/DinkPlugin/pull/286")
+    void testIgnoreWhispererNpcLootReceived() {
         // prepare mocks
         NPC npc = mock(NPC.class);
         String name = "The Whisperer";
@@ -140,7 +139,7 @@ class LootNotifierTest extends MockedNotifierTest {
         NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)));
         plugin.onNpcLootReceived(event);
 
-        // verify notification message
+        // ensure no notification
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 


### PR DESCRIPTION
Closes #282

Related: https://github.com/runelite/runelite/commit/c2dfda9ede854a5d3f8aeabd1facee36d3951568#diff-54526cb6ca5997b52b0c3195802d3299ccab3e74ed63b9e76d08871bdc2cf602R715 & https://discord.com/channels/301497432909414422/419891709883973642/1138628715199332372