### PR TITLE
feat: include kill count for npc loot notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Include NPC kill count in loot notifications. (#299)
 - Dev: Update gradle wrapper to v8.3 minor version. (#293)
 
 ## 1.6.2

--- a/README.md
+++ b/README.md
@@ -304,11 +304,14 @@ Note: Level 127 in JSON corresponds to attaining max experience in a skill (200M
       }
     ],
     "source": "Giant rat",
-    "category": "NPC"
+    "category": "NPC",
+    "killCount": 60
   },
   "type": "LOOT"
 }
 ```
+
+Note: `killCount` is only specified for NPC loot with the base RuneLite Loot Tracker plugin enabled.
 
 </details>
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -129,6 +129,7 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onUsernameChanged(UsernameChanged usernameChanged) {
         levelNotifier.reset();
+        lootNotifier.reset();
     }
 
     @Subscribe
@@ -214,7 +215,7 @@ public class DinkPlugin extends Plugin {
         deathNotifier.onInteraction(event);
     }
 
-    @Subscribe(priority = -1) // run after the base loot tracker plugin
+    @Subscribe(priority = 1) // run before the base loot tracker plugin
     public void onNpcLootReceived(NpcLootReceived npcLootReceived) {
         lootNotifier.onNpcLootReceived(npcLootReceived);
     }

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -214,7 +214,7 @@ public class DinkPlugin extends Plugin {
         deathNotifier.onInteraction(event);
     }
 
-    @Subscribe
+    @Subscribe(priority = -1) // run after the base loot tracker plugin
     public void onNpcLootReceived(NpcLootReceived npcLootReceived) {
         lootNotifier.onNpcLootReceived(npcLootReceived);
     }

--- a/src/main/java/dinkplugin/notifiers/data/LootNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/LootNotificationData.java
@@ -4,9 +4,10 @@ import dinkplugin.message.Field;
 import dinkplugin.util.ItemUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import net.runelite.client.util.QuantityFormatter;
 import net.runelite.http.api.loottracker.LootRecordType;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 @Value
@@ -15,14 +16,25 @@ public class LootNotificationData extends NotificationData {
     List<SerializedItemStack> items;
     String source;
     LootRecordType category;
+    Integer killCount;
 
     @Override
     public List<Field> getFields() {
-        return Collections.singletonList(
+        List<Field> fields = new ArrayList<>(2);
+        if (killCount != null) {
+            fields.add(
+                new Field(
+                    "Kill Count",
+                    Field.formatBlock("", QuantityFormatter.quantityToStackSize(killCount))
+                )
+            );
+        }
+        fields.add(
             new Field(
                 "Total Value",
                 ItemUtils.formatGold(items.stream().mapToLong(SerializedItemStack::getTotalPrice).sum())
             )
         );
+        return fields;
     }
 }

--- a/src/main/java/dinkplugin/util/SerializedLoot.java
+++ b/src/main/java/dinkplugin/util/SerializedLoot.java
@@ -4,6 +4,11 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * Contains kill count observed by base runelite loot tracker plugin, stored in profile configuration.
+ *
+ * @see <a href="https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ConfigLoot.java#L41">RuneLite class</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 public class SerializedLoot {

--- a/src/main/java/dinkplugin/util/SerializedLoot.java
+++ b/src/main/java/dinkplugin/util/SerializedLoot.java
@@ -1,0 +1,11 @@
+package dinkplugin.util;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SerializedLoot {
+    private int kills;
+}

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -100,7 +100,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, kc))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, kc + 1))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -126,7 +126,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, null))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, 1))
                 .type(NotificationType.LOOT)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -20,6 +20,7 @@ import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.plugins.loottracker.LootReceived;
+import net.runelite.client.plugins.loottracker.LootTrackerConfig;
 import net.runelite.client.util.QuantityFormatter;
 import net.runelite.http.api.loottracker.LootRecordType;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -78,6 +80,10 @@ class LootNotifierTest extends MockedNotifierTest {
         NPC npc = mock(NPC.class);
         String name = "Rasmus";
         when(npc.getName()).thenReturn(name);
+        int kc = 69;
+        when(configManager.getConfiguration(eq(LootTrackerConfig.GROUP), any(), eq("drops_NPC_" + name)))
+            .thenReturn("{\"type\":\"NPC\",\"name\":\"Rasmus\",\"kills\":" + kc +
+                ",\"first\":1667708688588,\"last\":1667708688588,\"drops\":[526,69,1603,1]}");
 
         // fire event
         NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)));
@@ -94,7 +100,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, kc))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -120,7 +126,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -174,7 +180,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -208,7 +214,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), source, LootRecordType.EVENT))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), source, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -248,7 +254,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
                         .build()
                 )
-                .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER))
+                .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -298,7 +304,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{opal}}", Replacements.ofWiki("Opal"))
                         .build()
                 )
-                .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.OPAL, 1, OPAL_PRICE, "Opal"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
+                .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.OPAL, 1, OPAL_PRICE, "Opal"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -334,7 +340,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{tuna}}", Replacements.ofWiki("Tuna"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 5, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 5, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
                 .build()
         );
@@ -371,7 +377,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{whip}}", Replacements.ofWiki("Abyssal Whip"))
                         .build()
                 )
-                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.ABYSSAL_WHIP, 1, whipPrice, "Abyssal Whip")), source, LootRecordType.EVENT))
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.ABYSSAL_WHIP, 1, whipPrice, "Abyssal Whip")), source, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
                 .build()
         );


### PR DESCRIPTION
Closes #296 (Related https://github.com/RinZJ/better-discord-loot-logger/issues/22)

![image](https://github.com/pajlads/DinkPlugin/assets/8106344/d01a30c0-20fd-4214-bd74-94074c68347c)

This PR relies upon the base loot tracker plugin observing all kills. In a future PR, we will use boss chat messages to override base loot tracker for more accurate kc stats
