### PR TITLE
feat: add allowlist filter mode for rsn advanced config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Add allowlist mode for RSN-based notification filter under the Advanced category. Use this setting with caution. (#306)
+- Minor: Add allowlist mode for Filtered RSNs under the Advanced category. Use this setting with caution. (#306)
 - Minor: Send kill count notifications for Penance Queen kills. (#304)
 - Minor: Include popup notification widget in collection log screenshots. (#309)
 - Minor: Support new thread creation for Discord forum channels. (#302)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Minor: Include NPC kill count in loot notifications. (#299)
 - Minor: Add option to disable price in Group Storage notifications. (#298)
 - Minor: Add `%TOTAL_LEVEL%` message template for level notifications. (#300)
+- Minor: You can now specify an allowlist of RSNs to fire notifications for instead under the Advanced category. Use this setting with caution. (#306)
 - Dev: Update gradle wrapper to v8.3 minor version. (#293)
 
 ## 1.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add allowlist mode for RSN-based notification filter under the Advanced category. Use this setting with caution. (#306)
 - Minor: Send kill count notifications for Penance Queen kills. (#304)
 - Minor: Include popup notification widget in collection log screenshots. (#309)
 - Minor: Support new thread creation for Discord forum channels. (#302)
@@ -7,7 +8,6 @@
 - Minor: Include NPC kill count in loot notifications. (#299)
 - Minor: Add option to disable price in Group Storage notifications. (#298)
 - Minor: Add `%TOTAL_LEVEL%` message template for level notifications. (#300)
-- Minor: You can now specify an allowlist of RSNs to fire notifications for instead under the Advanced category. Use this setting with caution. (#306)
 - Dev: Update gradle wrapper to v8.3 minor version. (#293)
 
 ## 1.6.2

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Some notifiers require in-game settings to be configured to send chat messages u
 - Screenshots can be individually configured for each notifier
 - Screenshots are compressed if needed to comply with Discord limits
 - The chat box (and private messages above chat) can be hidden from screenshots
-- The plugin can skip notifications if the current player name is on the user-configured RSN ignore list
+- The plugin can skip notifications if the current player name based on the user-configured RSN filter list
 - Users can choose whether their webhook messages are sent in Discord's rich embed format or a traditional format
 - The player name in Discord rich embeds can be linked to various tracking services (from HiScores to Wise Old Man)
 - Discord rich embed footers can be customized with user-specified text and image url
@@ -93,7 +93,7 @@ For example: `::dinkexport pet` or `::dinkexport collectionlog`.
 With the output of the above command (`::dinkexport`) copied to your clipboard, you can merge these settings with your own via the `::dinkimport` chat command.
 
 This import can replace all of your notifier settings.
-However, webhook URL lists and ignored RSNs will be combined, rather than outright replaced.
+However, webhook URL lists and filtered RSNs will be combined, rather than outright replaced.
 If you would like all settings overwritten rather than merged during import, simply press the `Reset` button at the bottom of the plugin settings panel to clear out all settings (including URLs) before running `::dinkimport`.
 
 After an import, if the dink plugin settings panel was open, simply close and open it for the updated configuration to be reflected in the user interface.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Some notifiers require in-game settings to be configured to send chat messages u
 - Screenshots can be individually configured for each notifier
 - Screenshots are compressed if needed to comply with Discord limits
 - The chat box (and private messages above chat) can be hidden from screenshots
-- The plugin can skip notifications if the current player name based on the user-configured RSN filter list
+- The plugin can skip notifications for player names that do not comply with the user-configured RSN filter list
 - Users can choose whether their webhook messages are sent in Discord's rich embed format or a traditional format
 - The player name in Discord rich embeds can be linked to various tracking services (from HiScores to Wise Old Man)
 - Discord rich embed footers can be customized with user-specified text and image url

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -256,7 +256,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "nameFilterMode",
         name = "RSN Filter Mode",
-        description = "Allow Mode: Only allow notifications for RSNs on the list above.<br/>" +
+        description = "Allow Mode: Only allow notifications for RSNs on the list above (discouraged).<br/>" +
             "Deny Mode: Prevent notifications from RSNs on the list above (default/recommended).",
         position = 1008,
         section = advancedSection

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -3,6 +3,7 @@ package dinkplugin;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.domain.ClueTier;
 import dinkplugin.domain.CombatAchievementTier;
+import dinkplugin.domain.FilterMode;
 import dinkplugin.domain.PlayerLookupService;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
@@ -241,21 +242,34 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "ignoredNames",
-        name = "Ignored RSNs",
-        description = "Prevent notifications from the following player names (One name per line)",
+        keyName = "ignoredNames", // historical name, preserved for backwards compatibility
+        name = "Filtered RSNs",
+        description = "Restrict what player names can trigger notifications (One name per line)<br/>" +
+            "This acts as an allowlist or denylist based on the 'RSN Filter Mode' setting below.",
         position = 1007,
         section = advancedSection
     )
-    default String ignoredNames() {
+    default String filteredNames() {
         return "";
+    }
+
+    @ConfigItem(
+        keyName = "nameFilterMode",
+        name = "RSN Filter Mode",
+        description = "Allow Mode: Only allow notifications for RSNs on the list above.<br/>" +
+            "Deny Mode: Prevent notifications from RSNs on the list above (default/recommended).",
+        position = 1008,
+        section = advancedSection
+    )
+    default FilterMode nameFilterMode() {
+        return FilterMode.DENY;
     }
 
     @ConfigItem(
         keyName = "playerLookupService",
         name = "Player Lookup Service",
         description = "The service used to lookup a players account, to make their name clickable in Discord embeds",
-        position = 1008,
+        position = 1009,
         section = advancedSection
     )
     default PlayerLookupService playerLookupService() {
@@ -267,7 +281,7 @@ public interface DinkPluginConfig extends Config {
         name = "Hide Chat in Images",
         description = "Whether to hide the chat box and private messages when capturing screenshots.<br/>" +
             "Note: visually you may notice the chat box momentarily flicker as it is hidden for the screenshot.",
-        position = 1009,
+        position = 1010,
         section = advancedSection
     )
     default boolean screenshotHideChat() {
@@ -278,7 +292,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "sendDiscordUser",
         name = "Send Discord Profile",
         description = "Whether to send your discord user information to the webhook server via metadata",
-        position = 1010,
+        position = 1011,
         section = advancedSection
     )
     default boolean sendDiscordUser() {
@@ -289,7 +303,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "sendClanName",
         name = "Send Clan Name",
         description = "Whether to send your clan information to the webhook server via metadata",
-        position = 1011,
+        position = 1012,
         section = advancedSection
     )
     default boolean sendClanName() {
@@ -300,7 +314,7 @@ public interface DinkPluginConfig extends Config {
         keyName = "sendGroupIronClanName",
         name = "Send GIM Clan Name",
         description = "Whether to send your group ironman clan information to the webhook server via metadata",
-        position = 1012,
+        position = 1013,
         section = advancedSection
     )
     default boolean sendGroupIronClanName() {

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -84,7 +84,7 @@ public class SettingsManager {
     private final ConfigManager configManager;
 
     /**
-     * Check whether a username adheres to the configured RSN filter list.
+     * Check whether a username complies with the configured RSN filter list.
      *
      * @param name the local player's name
      * @return whether notifications for this player should be sent

--- a/src/main/java/dinkplugin/domain/FilterMode.java
+++ b/src/main/java/dinkplugin/domain/FilterMode.java
@@ -1,0 +1,16 @@
+package dinkplugin.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FilterMode {
+    ALLOW("Exclusively Allow"),
+    DENY("Selectively Deny");
+
+    private final String displayName;
+
+    @Override
+    public String toString() {
+        return this.displayName;
+    }
+}

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -7,6 +7,7 @@ import dinkplugin.DinkPluginConfig;
 import dinkplugin.MockedTestBase;
 import dinkplugin.SettingsManager;
 import dinkplugin.domain.AccountType;
+import dinkplugin.domain.FilterMode;
 import dinkplugin.domain.PlayerLookupService;
 import dinkplugin.message.DiscordMessageHandler;
 import dinkplugin.message.templating.Template;
@@ -128,6 +129,7 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(config.embedFooterText()).thenReturn("Powered by Dink");
         when(config.embedFooterIcon()).thenReturn("https://github.com/pajlads/DinkPlugin/raw/master/icon.png");
         when(config.playerLookupService()).thenReturn(PlayerLookupService.OSRS_HISCORE);
+        when(config.nameFilterMode()).thenReturn(FilterMode.DENY);
     }
 
     protected void mockItem(int id, int price, String name) {

--- a/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
@@ -303,7 +303,7 @@ class PetNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyIrrelevantNameIgnore() {
         // ignore notifications for an irrelevant player
-        when(config.ignoredNames()).thenReturn("xqc");
+        when(config.filteredNames()).thenReturn("xqc");
         settingsManager.init();
 
         // send fake message
@@ -325,7 +325,7 @@ class PetNotifierTest extends MockedNotifierTest {
     @Test
     void testIgnoredPlayerName() {
         // ignore notifications for our player name
-        when(config.ignoredNames()).thenReturn(PLAYER_NAME);
+        when(config.filteredNames()).thenReturn(PLAYER_NAME);
         settingsManager.init();
 
         // send fake message

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -114,7 +114,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyDenyList() {
         // configure irrelevant deny list
-        when(config.ignoredNames()).thenReturn("pajlads");
+        when(config.filteredNames()).thenReturn("pajlads");
         settingsManager.init();
 
         // mock widget
@@ -141,7 +141,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
     @Test
     void testIgnoreDenyList() {
         // configure deny list
-        when(config.ignoredNames()).thenReturn(PLAYER_NAME);
+        when(config.filteredNames()).thenReturn(PLAYER_NAME);
         settingsManager.init();
 
         // mock widget


### PR DESCRIPTION
Closes #305

Uses @Felanbird's suggestion of a single input box and allow/deny toggle in https://github.com/pajlads/DinkPlugin/pull/114#issuecomment-1375997995 to avoid complexity of the initial approach of having a separate box for the allowlist and denylist.

Still, we discourage use of the allow filter mode since users can get confused when a new account does not fire notifications (because they have not added it to the input box).

![config](https://github.com/pajlads/DinkPlugin/assets/8106344/781e739d-7c65-4d80-8e92-134ee7886acf)

