### PR TITLE
Release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.6.3
+
 - Minor: Add item name allowlist and denylist for loot notifications. (#310)
 - Minor: Add allowlist mode for Filtered RSNs under the Advanced category. Use this setting with caution. (#306)
 - Minor: Send kill count notifications for Penance Queen kills. (#304)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.6.2"
+version = "1.6.3"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.6.3 augments notification information and plugin configurability, while expanding webhook support to Discord forum channels. Most notably, loot notifications now include the associated NPC kill count, and filters by item name can be applied to determine whether a loot notification should be triggered. In addition, pet notifications now indicate whether the pet was a duplicate, and level notification messages can include the updated total level of the player.
