### PR TITLE
feat: capture screenshots for toa deaths earlier

### DIFF
--- a/src/main/java/dinkplugin/notifiers/BaseNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/BaseNotifier.java
@@ -9,6 +9,8 @@ import net.runelite.api.Client;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
+import java.awt.Image;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class BaseNotifier {
 
@@ -31,9 +33,13 @@ public abstract class BaseNotifier {
     protected abstract String getWebhookUrl();
 
     protected final void createMessage(boolean sendImage, NotificationBody<?> body) {
+        this.createMessage(sendImage, null, body);
+    }
+
+    protected final void createMessage(boolean sendImage, CompletableFuture<Image> screenshot, NotificationBody<?> body) {
         String overrideUrl = getWebhookUrl();
         String url = StringUtils.isNotBlank(overrideUrl) ? overrideUrl : config.primaryWebhook();
-        messageHandler.createMessage(url, sendImage, body);
+        messageHandler.createMessage(url, sendImage, body, screenshot);
     }
 
 }

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -8,6 +8,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
+import net.runelite.client.ui.DrawManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 import okhttp3.Call;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.imageio.ImageIO;
 import javax.swing.SwingUtilities;
 import java.awt.Color;
+import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
@@ -196,6 +198,12 @@ public class Utils {
             MediaType type = part.body().contentType();
             return type != null && "image".equals(type.type());
         });
+    }
+
+    public CompletableFuture<Image> captureScreenshot(@NotNull DrawManager drawManager) {
+        CompletableFuture<Image> future = new CompletableFuture<>();
+        drawManager.requestNextFrameListener(future::complete);
+        return future;
     }
 
     public CompletableFuture<String> readClipboard() {

--- a/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ClueNotifierTest.java
@@ -88,7 +88,8 @@ class ClueNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new ClueNotificationData("medium", 1312, Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"))))
                 .type(NotificationType.CLUE)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -114,7 +115,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event);
 
         // ensure no notification was fired
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -139,7 +140,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event);
 
         // ensure no notification was fired
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -167,7 +168,7 @@ class ClueNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event);
 
         // ensure no notification was fired
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
@@ -77,7 +77,8 @@ class CollectionNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new CollectionNotificationData(item, ItemID.SEERCULL, (long) price, 1, TOTAL_ENTRIES))
                 .type(NotificationType.COLLECTION)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -117,7 +118,8 @@ class CollectionNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new CollectionNotificationData(item, ItemID.SEERCULL, (long) price, 1, TOTAL_ENTRIES))
                 .type(NotificationType.COLLECTION)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -127,7 +129,7 @@ class CollectionNotifierTest extends MockedNotifierTest {
         notifier.onChatMessage("New item added to your backpack: weed");
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -140,7 +142,7 @@ class CollectionNotifierTest extends MockedNotifierTest {
         notifier.onChatMessage("New item added to your collection log: " + item);
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CombatTaskNotifierTest.java
@@ -76,7 +76,8 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
                 .extra(new CombatAchievementData(CombatAchievementTier.HARD, "Whack-a-Mole", 3, 200, 85, 189, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -103,7 +104,8 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 1466, 1466 - 1465, 2005 - 1465, CombatAchievementTier.MASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -130,7 +132,8 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
                 .extra(new CombatAchievementData(CombatAchievementTier.GRANDMASTER, "No Pressure", 6, 2005, null, null, CombatAchievementTier.GRANDMASTER))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.COMBAT_ACHIEVEMENT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -140,7 +143,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
         notifier.onGameMessage("Congratulations, you've completed an easy combat task: A Slow Death.");
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -149,7 +152,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
         notifier.onGameMessage("Congratulations, you've completed a gachi combat task: Swordfight with the homies.");
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -161,7 +164,7 @@ class CombatTaskNotifierTest extends MockedNotifierTest {
         notifier.onGameMessage("Congratulations, you've completed a hard combat task: Whack-a-Mole.");
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static Template buildUnlockTemplate(String tier, String task) {

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -102,7 +102,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -148,7 +149,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
                 .embeds(embeds)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -173,7 +175,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0)))
                 .extra(new DeathNotificationData(0L, true, pker, pker, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -200,7 +203,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has been PKed by %s for %d gp", PLAYER_NAME, pker, 0)))
                 .extra(new DeathNotificationData(0L, true, pker, pker, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -224,7 +228,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -272,7 +277,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new DeathNotificationData(0L, false, null, name, NpcID.GUARD, Collections.emptyList(), Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -313,7 +319,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -353,7 +360,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, kept, Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -375,7 +383,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(inv.getItems()).thenReturn(items);
 
         // fire event
-        notifier.onGameMessage("You failed to survive the Tombs of Amascut");
+        notifier.onGameMessage(DeathNotifier.TOA_DEATH_MSG);
 
         // verify notification
         List<SerializedItemStack> kept = Arrays.asList(
@@ -394,7 +402,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -431,7 +440,8 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, 0)))
                 .extra(new DeathNotificationData(0L, false, null, null, null, kept, Collections.emptyList()))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -473,11 +483,12 @@ class DeathNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
                 .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost))
                 .type(NotificationType.DEATH)
-                .build()
+                .build(),
+            null
         );
 
         // ensure TOA death chat message is ignored for HCIM
-        notifier.onGameMessage("You failed to survive the Tombs of Amascut");
+        notifier.onGameMessage(DeathNotifier.TOA_DEATH_MSG);
         Mockito.verifyNoMoreInteractions(messageHandler);
     }
 
@@ -501,7 +512,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -513,7 +524,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         plugin.onActorDeath(new ActorDeath(other));
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -525,7 +536,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -537,7 +548,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -560,7 +571,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         plugin.onActorDeath(new ActorDeath(localPlayer));
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DiaryNotifierTest.java
@@ -67,7 +67,8 @@ class DiaryNotifierTest extends MockedNotifierTest {
                 .extra(new DiaryNotificationData("Desert", AchievementDiary.Difficulty.ELITE, 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -93,7 +94,8 @@ class DiaryNotifierTest extends MockedNotifierTest {
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -118,7 +120,8 @@ class DiaryNotifierTest extends MockedNotifierTest {
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -144,7 +147,8 @@ class DiaryNotifierTest extends MockedNotifierTest {
                 .extra(new DiaryNotificationData("Western Provinces", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -170,7 +174,8 @@ class DiaryNotifierTest extends MockedNotifierTest {
                 .extra(new DiaryNotificationData("Karamja", AchievementDiary.Difficulty.HARD, total + 1))
                 .type(NotificationType.ACHIEVEMENT_DIARY)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
 
         // trigger message box
@@ -193,7 +198,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
         plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -209,7 +214,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
         plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -219,7 +224,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
         plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -235,7 +240,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
         plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -254,7 +259,7 @@ class DiaryNotifierTest extends MockedNotifierTest {
         plugin.onVarbitChanged(event(id, 1));
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static VarbitChanged event(int id, int value) {

--- a/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GambleNotifierTest.java
@@ -67,7 +67,8 @@ public class GambleNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " has reached 20 high gambles"))
                 .extra(new GambleNotificationData(20, Collections.singletonList(new SerializedItemStack(ItemID.GRANITE_HELM, 1, GRANITE_HELM_PRICE, "Granite helm"))))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -85,14 +86,15 @@ public class GambleNotifierTest extends MockedNotifierTest {
                     new SerializedItemStack(ItemID.CLUE_SCROLL_ELITE, 1, ELITE_CLUE_PRICE, "Clue scroll (elite)")
                 )))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
-                .build()
+                .build(),
+            null
         );
     }
 
     @Test
     void testIgnoredInterval() {
         notifier.onMesBoxNotification("Watermelon seed (x 50)! High level gamble count: 21.");
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -111,7 +113,8 @@ public class GambleNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new GambleNotificationData(11, Collections.singletonList(new SerializedItemStack(ItemID.DRAGON_CHAINBODY, 1, DRAGON_CHAINBODY_PRICE, "Dragon chainbody"))))
                 .type(NotificationType.BARBARIAN_ASSAULT_GAMBLE)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -119,13 +122,13 @@ public class GambleNotifierTest extends MockedNotifierTest {
     void testIgnoredRareLootInterval() {
         when(config.gambleRareLoot()).thenReturn(false);
         notifier.onMesBoxNotification("Dragon chainbody! High level gamble count: 13.");
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
     void testDisabled() {
         when(config.notifyGamble()).thenReturn(false);
         notifier.onMesBoxNotification("Dragon chainbody! High level gamble count: 100.");
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 }

--- a/src/test/java/dinkplugin/notifiers/GrandExchangeNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GrandExchangeNotifierTest.java
@@ -76,7 +76,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(1, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(0, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(1, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -185,7 +185,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(0, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -195,7 +195,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(0, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -208,7 +208,7 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
         notifier.onOfferChange(0, offer);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private void verifyNotification(int slot, Offer offer, String type, String itemName, long marketPrice, Long tax) {
@@ -230,7 +230,8 @@ public class GrandExchangeNotifierTest extends MockedNotifierTest {
                 .embeds(Collections.singletonList(Embed.ofImage(ItemUtils.getItemImageUrl(item.getId()))))
                 .extra(new GrandExchangeNotificationData(slot + 1, offer.getState(), item, marketPrice, offer.getPrice(), offer.getTotalQuantity(), tax))
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 

--- a/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
@@ -302,7 +302,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         notifier.onWidgetClose(CLOSE_EVENT);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -323,7 +323,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         notifier.onWidgetClose(CLOSE_EVENT);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -341,7 +341,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         notifier.onWidgetClose(CLOSE_EVENT);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -360,7 +360,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         notifier.onWidgetClose(CLOSE_EVENT);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private void verifyNotification(GroupStorageNotificationData extra, String deposited, String withdrawn) {
@@ -382,7 +382,8 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
                 .extra(extra)
                 .type(NotificationType.GROUP_STORAGE)
                 .playerName(PLAYER_NAME)
-                .build()
+                .build(),
+            null
         );
     }
 

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -78,7 +78,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            body
+            body,
+            null
         );
 
         assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
@@ -104,7 +105,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("King Black Dragon", 1, gameMessage, null, null))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -120,7 +122,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -136,7 +138,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -161,7 +163,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            body
+            body,
+            null
         );
 
         assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
@@ -190,7 +193,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            body
+            body,
+            null
         );
 
         assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
@@ -219,7 +223,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            body
+            body,
+            null
         );
 
         assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
@@ -245,7 +250,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Zulrah", 1, gameMessage, Duration.ofHours(1).plusSeconds(56).plusMillis(500), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -272,7 +278,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
         verify(messageHandler).createMessage(
             PRIMARY_WEBHOOK_URL,
             true,
-            body
+            body,
+            null
         );
 
         assertDoesNotThrow(() -> RuneLiteAPI.GSON.toJson(body));
@@ -298,7 +305,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Chambers of Xeric", 125, gameMessage, Duration.ofMinutes(36).plusSeconds(4).plusMillis(200), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -323,7 +331,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Chambers of Xeric", 150, gameMessage, Duration.ofMinutes(46).plusSeconds(31).plusMillis(800), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -347,7 +356,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Crystalline Hunllef", 10, gameMessage, Duration.ofMinutes(10).plusSeconds(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -371,7 +381,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Tempoross", 69, gameMessage, Duration.ofMinutes(6).plusSeconds(30), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -395,7 +406,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Tombs of Amascut: Expert Mode", 8, gameMessage, Duration.ofMinutes(25), true))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -419,7 +431,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .extra(new BossNotificationData("Zulrah", 12, gameMessage, Duration.ofSeconds(59).plusMillis(300), false))
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -456,7 +469,8 @@ class KillCountNotifierTest extends MockedNotifierTest {
                 .playerName(PLAYER_NAME)
                 .type(NotificationType.KILL_COUNT)
                 .embeds(Collections.singletonList(Embed.ofImage(ItemUtils.getNpcImageUrl(NpcID.PENANCE_QUEEN))))
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -476,7 +490,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -491,7 +505,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -506,7 +520,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -521,7 +535,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -536,7 +550,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -551,7 +565,7 @@ class KillCountNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static Template buildTemplate(String boss, int count) {

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -91,7 +91,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -118,7 +119,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 6), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -145,7 +147,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Attack", 100), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -172,7 +175,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Hunter", 127), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -204,7 +208,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Hunter", 99), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -238,7 +243,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Agility", 5, "Attack", 100, "Hunter", 5), expectedSkills, unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -270,7 +276,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(Collections.emptyMap(), expectedSkills, combatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -303,7 +310,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Hitpoints", 13), expectedSkills, combatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -324,7 +332,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -336,7 +344,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -360,7 +368,8 @@ class LevelNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LevelNotificationData(ImmutableMap.of("Slayer", 97), skillsMap("Slayer", 97), unchangedCombatLevel))
                 .type(NotificationType.LEVEL)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -376,7 +385,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -391,7 +400,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -411,7 +420,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -426,7 +435,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         IntStream.range(0, 4).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private void mockLevel(Skill skill, int level) {

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -102,7 +102,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, kc + 1))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -130,7 +131,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -158,7 +160,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -170,7 +173,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -181,7 +184,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -206,7 +209,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), name, LootRecordType.NPC, 1))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -224,7 +228,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -238,7 +242,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -260,7 +264,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -271,7 +276,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -294,7 +299,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), source, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -308,7 +314,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -334,7 +340,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.PLAYER, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -350,7 +357,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onPlayerLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -384,7 +391,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Arrays.asList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby"), new SerializedItemStack(ItemID.OPAL, 1, OPAL_PRICE, "Opal"), new SerializedItemStack(ItemID.TUNA, 1, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -420,7 +428,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.TUNA, 5, TUNA_PRICE, "Tuna")), LOOTED_NAME, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -457,7 +466,8 @@ class LootNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.ABYSSAL_WHIP, 1, whipPrice, "Abyssal Whip")), source, LootRecordType.EVENT, null))
                 .type(NotificationType.LOOT)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -479,7 +489,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -492,7 +502,7 @@ class LootNotifierTest extends MockedNotifierTest {
         plugin.onLootReceived(event);
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PetNotifierTest.java
@@ -61,7 +61,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .extra(new PetNotificationData(null, null, false, null))
                 .text(buildTemplate(PLAYER_NAME + " feels something weird sneaking into their backpack"))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -82,7 +83,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .extra(new PetNotificationData(null, null, true, true))
                 .text(buildTemplate(PLAYER_NAME + " has a funny feeling like they would have been followed..."))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -109,7 +111,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -136,7 +139,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -162,7 +166,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -188,7 +193,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -211,7 +217,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -250,7 +257,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -288,7 +296,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .thumbnailUrl(ItemUtils.getItemImageUrl(itemId))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -312,7 +321,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .extra(new PetNotificationData(null, null, false, null))
                 .text(buildTemplate(PLAYER_NAME + " has a funny feeling like they're being followed"))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -323,7 +333,7 @@ class PetNotifierTest extends MockedNotifierTest {
         IntStream.rangeClosed(0, MAX_TICKS_WAIT).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -336,7 +346,7 @@ class PetNotifierTest extends MockedNotifierTest {
         IntStream.rangeClosed(0, MAX_TICKS_WAIT).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -357,7 +367,8 @@ class PetNotifierTest extends MockedNotifierTest {
                 .extra(new PetNotificationData(null, null, false, null))
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .type(NotificationType.PET)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -380,7 +391,9 @@ class PetNotifierTest extends MockedNotifierTest {
                 .extra(new PetNotificationData(null, null, false, null))
                 .text(buildTemplate(PLAYER_NAME + " got a pet"))
                 .type(NotificationType.PET)
-                .build());
+                .build(),
+            null
+        );
     }
 
     @Test
@@ -395,7 +408,7 @@ class PetNotifierTest extends MockedNotifierTest {
         IntStream.rangeClosed(0, MAX_TICKS_WAIT).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -409,7 +422,7 @@ class PetNotifierTest extends MockedNotifierTest {
         IntStream.rangeClosed(0, MAX_TICKS_WAIT).forEach(i -> notifier.onTick());
 
         // ensure no notification occurred
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/PlayerKillNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/PlayerKillNotifierTest.java
@@ -101,7 +101,8 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, damage))
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -124,7 +125,8 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, 12))
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -151,7 +153,8 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
                 .type(NotificationType.PLAYER_KILL)
                 .playerName(PLAYER_NAME)
                 .extra(new PlayerKillNotificationData(TARGET, LEVEL, EQUIPMENT, WORLD, LOCATION, MY_HP, damage))
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -166,7 +169,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -179,7 +182,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -196,7 +199,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -211,7 +214,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -225,7 +228,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -241,7 +244,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -254,7 +257,7 @@ public class PlayerKillNotifierTest extends MockedNotifierTest {
         notifier.onTick();
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static Player mockPlayer() {

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -69,7 +69,8 @@ class QuestNotifierTest extends MockedNotifierTest {
                 )
                 .extra(new QuestNotificationData("Dragon Slayer I", 22, 156, 44, 293))
                 .type(NotificationType.QUEST)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -79,7 +80,7 @@ class QuestNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event(-1));
 
         // verify no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -96,7 +97,7 @@ class QuestNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event(QUEST_COMPLETED_GROUP_ID));
 
         // verify no message
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static WidgetLoaded event(int id) {

--- a/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SlayerNotifierTest.java
@@ -48,7 +48,8 @@ class SlayerNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(1, "TzTok-Jad", 10, 100))
                 .extra(new SlayerNotificationData("1 TzTok-Jad", "100", "10", 1, "TzTok-Jad"))
                 .type(NotificationType.SLAYER)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -68,7 +69,8 @@ class SlayerNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(245, "Cave Kraken", "1,000", "1,000"))
                 .extra(new SlayerNotificationData("245 Cave Kraken", "1,000", "1,000", 245, "Cave Kraken"))
                 .type(NotificationType.SLAYER)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -87,7 +89,8 @@ class SlayerNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(50, "Cave Kraken", 10, 150))
                 .extra(new SlayerNotificationData("50 Cave Kraken", "150", "10", 50, "Cave Kraken"))
                 .type(NotificationType.SLAYER)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -106,7 +109,8 @@ class SlayerNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(36, "Barrows brothers", 20, 881))
                 .extra(new SlayerNotificationData("36 Barrows brothers", "881", "20", 36, "Barrows brothers"))
                 .type(NotificationType.SLAYER)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -125,7 +129,8 @@ class SlayerNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(11, "Chaos Elemental", 15, 242))
                 .extra(new SlayerNotificationData("11 Chaos Elemental", "242", "15", 11, "Chaos Elemental"))
                 .type(NotificationType.SLAYER)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -136,7 +141,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
         notifier.onChatMessage("You've completed 101 tasks and received 0 points, giving you a total of 200; return to a Slayer master.");
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -149,7 +154,7 @@ class SlayerNotifierTest extends MockedNotifierTest {
         notifier.onChatMessage("You've completed 100 tasks and received 10 points, giving you a total of 200; return to a Slayer master.");
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private static Template buildTemplate(int count, String monster, Object points, Object completed) {

--- a/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/SpeedrunNotifierTest.java
@@ -74,7 +74,8 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(QUEST_NAME, latest))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -91,7 +92,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event());
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -108,7 +109,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event());
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -134,7 +135,8 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
                 .text(buildTemplate(QUEST_NAME, latest))
                 .extra(new SpeedrunNotificationData(QUEST_NAME, Duration.ofMinutes(1).plusSeconds(30).plusMillis(250).toString(), Duration.ofMinutes(1).plusSeconds(15).plusMillis(300).toString()))
                 .type(NotificationType.SPEEDRUN)
-                .build()
+                .build(),
+            null
         );
     }
 
@@ -153,7 +155,7 @@ class SpeedrunNotifierTest extends MockedNotifierTest {
         plugin.onWidgetLoaded(event());
 
         // ensure no notification
-        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any(), any());
     }
 
     private WidgetLoaded event() {


### PR DESCRIPTION
Follow-up from https://github.com/pajlads/DinkPlugin/pull/317#issuecomment-1732614607

Should weigh whether the added complexity is worth the improved screenshot timing
