### PR TITLE
fix: make default setting for screenshots consistent across all notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Made the default setting for screenshots enabled for consistency across all notifiers. (#330)
 - Minor: Add key in the Speedrun notifier extra object for whether the run is a personal best or not. (#329)
 - Minor: Indicate in pet notification metadata when a pet was previously owned but lost. (#314)
 - Minor: Support wildcards in loot item name filters. (#312)

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -821,7 +821,7 @@ public interface DinkPluginConfig extends Config {
         section = deathSection
     )
     default boolean deathSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -916,7 +916,7 @@ public interface DinkPluginConfig extends Config {
         section = slayerSection
     )
     default boolean slayerSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -964,7 +964,7 @@ public interface DinkPluginConfig extends Config {
         section = questSection
     )
     default boolean questSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -999,7 +999,7 @@ public interface DinkPluginConfig extends Config {
         section = clueSection
     )
     default boolean clueSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -1143,7 +1143,7 @@ public interface DinkPluginConfig extends Config {
         section = killCountSection
     )
     default boolean killCountSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -1238,7 +1238,7 @@ public interface DinkPluginConfig extends Config {
         section = combatTaskSection
     )
     default boolean combatTaskSendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(
@@ -1304,7 +1304,7 @@ public interface DinkPluginConfig extends Config {
         section = diarySection
     )
     default boolean diarySendImage() {
-        return false;
+        return true;
     }
 
     @ConfigItem(


### PR DESCRIPTION
I went with on by default, I told the issue reporter that off by default was correct, but I realized that outside of death, what I would expect to be the most "common" notifiers are all already default on.