### PR TITLE
fix: allow first xp drop to trigger level notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Add key in the Speedrun notifier extra object for whether the run is a personal best or not. (#329)
 - Minor: Indicate in pet notification metadata when a pet was previously owned but lost. (#314)
 - Minor: Support wildcards in loot item name filters. (#312)
+- Bugfix: Allow the first xp drop in a skill after login to trigger level notifications. (#332)
 - Bugfix: Don't treat personal best ties as personal bests for Speedrun notifications. (#329)
 - Bugfix: Classify Gauntlet deaths as safe, unless the player is a hardcore ironman. (#327)
 - Bugfix: Classify deaths in Tombs of Abascut as safe or dangerous depending on the attempt invocations. (#317)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Minor: Add key in the Speedrun notifier extra object for whether the run is a personal best or not. (#329)
 - Minor: Indicate in pet notification metadata when a pet was previously owned but lost. (#314)
 - Minor: Support wildcards in loot item name filters. (#312)
-- Bugfix: Allow the first xp drop in a skill after login to trigger level notifications. (#332)
+- Bugfix: Allow the first xp drop after login to trigger level notifications. (#332)
 - Bugfix: Don't treat personal best ties as personal bests for Speedrun notifications. (#329)
 - Bugfix: Classify Gauntlet deaths as safe, unless the player is a hardcore ironman. (#327)
 - Bugfix: Classify deaths in Tombs of Abascut as safe or dangerous depending on the attempt invocations. (#317)

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -50,7 +50,8 @@ public class LevelNotifier extends BaseNotifier {
     }
 
     public void initLevels() {
-        if (initTicks.getAndSet(INIT_CLIENT_TICKS) > 0)
+        // initTicks == 0 => set initTicks to INIT_CLIENT_TICKS & schedule level lookup
+        if (initTicks.getAndUpdate(i -> i <= 0 ? INIT_CLIENT_TICKS : i) > 0)
             return; // init task is already queued
 
         clientThread.invokeLater(() -> {


### PR DESCRIPTION
Previously, upon first login, `initTicks` was constantly getting set to `INIT_CLIENT_TICKS` on tick, so level map initialization couldn't occur. Instead, upon gaining xp in a skill, would the level map be populated for that skill (and `initLevels` would be called, so full map initialization would occur a second later). Typically this is fine, unless the very first xp drop is sufficient to gain a level in the skill. This PR restores `currentLevels` initialization on login, to avoid this bug
