### PR TITLE
feat(metadata): include hashed account unique identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Include hashed account unique identifier in notification metadata. (#334)
 - Minor: Made the default setting for screenshots enabled for consistency across all notifiers. (#330)
 - Minor: Send character information on login to custom handlers via advanced config. (#321)
 - Minor: Add key in the Speedrun notifier extra object for whether the run is a personal best or not. (#329)

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -209,6 +209,14 @@ public class DiscordMessageHandler {
             mBody = mBody.withAccountType(Utils.getAccountType(client));
         }
 
+        if (mBody.getDinkAccountHash() == null) {
+            long id = client.getAccountHash();
+            if (id != -1) {
+                int offset = 4_9_14_11; // dink but A=1, B=2, C=3, ...
+                mBody = mBody.withDinkAccountHash(Utils.sha224(id + offset));
+            }
+        }
+
         NotificationBody.NotificationBodyBuilder<?> builder = mBody.toBuilder();
 
         if (config.sendDiscordUser()) {

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -212,8 +212,7 @@ public class DiscordMessageHandler {
         if (mBody.getDinkAccountHash() == null) {
             long id = client.getAccountHash();
             if (id != -1) {
-                int offset = 4_9_14_11; // dink but A=1, B=2, C=3, ...
-                mBody = mBody.withDinkAccountHash(Utils.sha224(id + offset));
+                mBody = mBody.withDinkAccountHash(Utils.dinkHash(id));
             }
         }
 

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -32,6 +32,7 @@ public class NotificationBody<T extends NotificationData> {
     NotificationType type;
     String playerName;
     AccountType accountType;
+    String dinkAccountHash;
     @Nullable
     String clanName;
     @Nullable

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -57,7 +57,7 @@ public class Utils {
 
     /**
      * Custom padding for applying SHA-256 to a long.
-     * SHA-256 adds 0 bits of padding such that L+1+K+64 mod 512 == 0.
+     * SHA-256 adds '0' padding bits such that L+1+K+64 mod 512 == 0.
      * Long is 64 bits and this padding is 376 bits, so L = 440. Thus, minimal K = 7.
      * This padding differentiates our hash results, and only incurs a ~1% performance penalty.
      *
@@ -273,6 +273,11 @@ public class Utils {
         return future;
     }
 
+    /**
+     * @param l the long to hash
+     * @return SHA-224 with custom padding
+     * @see #DINK_HASH_PADDING
+     */
     public String dinkHash(long l) {
         MessageDigest hash;
         try {

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -1,5 +1,6 @@
 package dinkplugin.util;
 
+import com.google.common.hash.HashCode;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import dinkplugin.DinkPluginConfig;
@@ -33,6 +34,9 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -255,6 +259,19 @@ public class Utils {
             }
         });
         return future;
+    }
+
+    public String sha224(long l) {
+        MessageDigest hash;
+        try {
+            hash = MessageDigest.getInstance("SHA-224");
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("Account hash will not be included in notification metadata", e);
+            return null;
+        }
+        byte[] input = ByteBuffer.allocate(8).putLong(l).array();
+        // noinspection UnstableApiUsage - no longer @Beta as of v32.0.0
+        return HashCode.fromBytes(hash.digest(input)).toString();
     }
 
 }


### PR DESCRIPTION
Closes #333

Uses SHA-224 as a sufficiently fast (my laptop achieves a throughput of over 2 million hashes per second, according to JMH) hash function (that doesn't require adding a new dependency) with resistance to collision attacks, preimage attacks, and length extension attacks, so that the underlying account identifier is not revealed (just in case other third party applications use this identifier as auth). If SHA-224 is not available (i.e., user has a very exotic JVM), `dinkAccountHash` is not specified.
