### PR TITLE
feat(loot): get kc from base rl chat commands plugin

### DIFF
--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -10,6 +10,7 @@ import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.GrandExchangeNotificationData;
 import dinkplugin.notifiers.data.SerializedItemStack;
+import dinkplugin.util.ConfigUtil;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.SerializedOffer;
 import dinkplugin.util.Utils;
@@ -23,7 +24,6 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.grandexchange.GrandExchangePlugin;
 
@@ -129,7 +129,7 @@ public class GrandExchangeNotifier extends BaseNotifier {
 
             // require GE plugin to be enabled so that observed trades are written to config
             // however: not bullet-proof since GE plugin could've been disabled during the initial trade completion
-            if ("false".equals(configManager.getConfiguration(RuneLiteConfig.GROUP_NAME, RL_GE_PLUGIN_NAME)))
+            if (ConfigUtil.isPluginDisabled(configManager, RL_GE_PLUGIN_NAME))
                 return false;
 
             // check whether the completion has already been observed

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -198,7 +198,7 @@ public class LootNotifier extends BaseNotifier {
     }
 
     private void handleNotify(Collection<ItemStack> items, String dropper, LootRecordType type) {
-        final Integer kc = type == LootRecordType.NPC ? incrementAndGetKillCount(dropper) : null;
+        final Integer kc = incrementAndGetKillCount(dropper, type);
         final int minValue = config.minLootValue();
         final boolean icons = config.lootIcons();
 
@@ -249,8 +249,9 @@ public class LootNotifier extends BaseNotifier {
         }
     }
 
-    private Integer incrementAndGetKillCount(String npcName) {
-        Integer stored = getStoredKillCount(npcName);
+    private Integer incrementAndGetKillCount(String npcName, LootRecordType type) {
+        if (type != LootRecordType.NPC && type != LootRecordType.EVENT) return null;
+        Integer stored = getStoredKillCount(npcName, type);
         if (stored == null) {
             killCounts.asMap().computeIfPresent(npcName, (k, v) -> v + 1);
             return null;
@@ -265,9 +266,10 @@ public class LootNotifier extends BaseNotifier {
 
     /**
      * @param npcName {@link NPC#getName()}
+     * @param type {@link LootReceived#getType()}
      * @return the kill count stored by the base runelite chat commands or loot tracker plugin
      */
-    private Integer getStoredKillCount(String npcName) {
+    private Integer getStoredKillCount(String npcName, LootRecordType type) {
         // Get kill count from base Chat Commands plugin, if enabled
         if (!ConfigUtil.isPluginDisabled(configManager, RL_CHAT_CMD_PLUGIN_NAME)) {
             String boss = "Barrows".equals(npcName) ? "barrows chests"
@@ -279,7 +281,7 @@ public class LootNotifier extends BaseNotifier {
             }
         }
 
-        if (ConfigUtil.isPluginDisabled(configManager, RL_LOOT_PLUGIN_NAME)) {
+        if (type != LootRecordType.NPC || ConfigUtil.isPluginDisabled(configManager, RL_LOOT_PLUGIN_NAME)) {
             // assume stored kc is useless if loot tracker plugin is disabled
             return null;
         }

--- a/src/main/java/dinkplugin/util/ConfigUtil.java
+++ b/src/main/java/dinkplugin/util/ConfigUtil.java
@@ -4,6 +4,8 @@ import lombok.experimental.UtilityClass;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.util.ColorUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +28,10 @@ public class ConfigUtil {
         return DELIM.splitAsStream(value)
             .map(String::trim)
             .filter(StringUtils::isNotEmpty);
+    }
+
+    public boolean isPluginDisabled(ConfigManager configManager, String simpleLowerClassName) {
+        return "false".equals(configManager.getConfiguration(RuneLiteConfig.GROUP_NAME, simpleLowerClassName));
     }
 
     @Nullable


### PR DESCRIPTION
Base RL Chat Commands plugin also tracks kill counts (from chat event, ring of wealth, and poh), so we can use it as another source of persistent kc data. Also, this introduces coverage for completion counts beyond individual npc kills (e.g., barrows chests, cox completions, tob completions, toa completions)

Related: #323 & #296
Complements #324
