### PR TITLE
chore: use lombok 1.18.30 despite jdk version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,7 @@ repositories {
 }
 
 dependencies {
-    val lombokVersion = if (JavaVersion.current() >= JavaVersion.VERSION_17) {
-        "1.18.30" // JDK17 support was added in 1.18.22, but we can utilize latest since plugin-hub runs JDK11
-    } else {
-        "1.18.20" // Most recent version (only supports up to JDK16) that is verified by runelite
-    }
+    val lombokVersion = "1.18.30" // supports JDK 21 and is verified by runelite
     // old annotation processor approach due to runelite plugin hub verification restrictions
     compileOnly(group = "org.projectlombok", name = "lombok", version = lombokVersion)
     annotationProcessor(group = "org.projectlombok", name = "lombok", version = lombokVersion)


### PR DESCRIPTION
Our lombok version workaround is no longer required due to https://github.com/runelite/plugin-hub/commit/c998876a32f5714cd9a9d247bdb2658e00ae6184