### PR TITLE
Release Dink v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.4
 
 - Minor: Add task progress metadata for diary notifications. (#331)
-- Minor: Use boss chat message for latest kill count in loot notifications. (#324)
+- Minor: Use boss chat message for latest kill count in loot notifications. This is only for "normal" bosses and won't yet work for things such as raids/barrows/hespori. (#324)
 - Minor: Include hashed account unique identifier in notification metadata. (#334)
 - Minor: Made the default setting for screenshots enabled for consistency across all notifiers. (#330)
 - Minor: Send character information on login to custom handlers via advanced config. (#321)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.6.4
+
 - Minor: Add task progress metadata for diary notifications. (#331)
 - Minor: Use boss chat message for latest kill count in loot notifications. (#324)
 - Minor: Include hashed account unique identifier in notification metadata. (#334)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.6.3"
+version = "1.6.4"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.6.4 fixes some bugs and includes new features. 

In particular, dangerous death detection is improved for CG/TOA, and the kill count notifier now reports the correct challenge duration/PB for (Corrupted) Gauntlet.

In terms of notable features, the diary notifier now includes individual task data, the loot notifier item filters now support wildcards, and a new notifier has been added to inform custom webhook handlers upon character login.
