### PR TITLE
feat(loot): add filtering for dropper source

### DIFF
--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -802,13 +802,26 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "lootSourceAllowlist",
+        name = "Source Allowlist",
+        description = "Only allow loot from specific sources to trigger notifications. Sources can be NPC names or special events.<br/>" +
+            "For example, 'Loot Chest' can be specified to only notify on PK loot chest openings.<br/>" +
+            "Place one source per line (case-insensitive; asterisks are wildcards)",
+        position = 39,
+        section = lootSection
+    )
+    default String lootSourceAllowlist() {
+        return "";
+    }
+
+    @ConfigItem(
         keyName = "lootNotifMessage",
         name = "Notification Message",
         description = "The message to be sent through the webhook.<br/>" +
             "Use %USERNAME% to insert your username<br/>" +
             "Use %LOOT% to insert the loot<br/>" +
             "Use %SOURCE% to show the source of the loot",
-        position = 39,
+        position = 40,
         section = lootSection
     )
     default String lootNotifyMessage() {

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -275,6 +275,46 @@ class LootNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testNotifySourceAllowlist() {
+        when(config.lootSourceAllowlist()).thenReturn(LOOTED_NAME);
+        notifier.init();
+
+        // fire event
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        plugin.onLootReceived(event);
+
+        // verify notification message
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            false,
+            NotificationBody.builder()
+                .text(
+                    Template.builder()
+                        .template(String.format("%s has looted: 1 x {{ruby}} (%d) from %s for %d gp", PLAYER_NAME, RUBY_PRICE, LOOTED_NAME, RUBY_PRICE))
+                        .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
+                        .build()
+                )
+                .extra(new LootNotificationData(Collections.singletonList(new SerializedItemStack(ItemID.RUBY, 1, RUBY_PRICE, "Ruby")), LOOTED_NAME, LootRecordType.PICKPOCKET, null))
+                .type(NotificationType.LOOT)
+                .build()
+        );
+
+    }
+
+    @Test
+    void testIgnoreSourceAllowlist() {
+        when(config.lootSourceAllowlist()).thenReturn("Romy");
+        notifier.init();
+
+        // fire event
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)), 1);
+        plugin.onLootReceived(event);
+
+        // ensure no notification
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
+    @Test
     void testNotifyClue() {
         // fire event
         String source = "Clue Scroll (Medium)";


### PR DESCRIPTION
Allows loot notifications to be filtered client-side on `extra.source`

Current implementation only has allowlist box, but we could add a toggle to change filter mode (here it may not make sense to have two boxes--one each for allowlist and denylist--since when allowlist is active, denylist would be ignored)
