### PR TITLE
feat(quest): use historical name for first Recipe for Disaster quest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Prefer historical name for first Recipe for Disaster quest. (#352)
+
 ## 1.6.4
 
 - Minor: Add task progress metadata for diary notifications. (#331)

--- a/src/main/java/dinkplugin/util/QuestUtils.java
+++ b/src/main/java/dinkplugin/util/QuestUtils.java
@@ -53,7 +53,8 @@ public class QuestUtils {
     private final Collection<String> RFD_TAGS = ImmutableList.of("Another Cook", "freed", "defeated", "saved");
     private final Collection<String> WORD_QUEST_IN_NAME_TAGS = ImmutableList.of("Another Cook", "Doric", "Heroes", "Legends", "Observatory", "Olaf", "Waterfall");
     private final Map<String, String> QUEST_REPLACEMENTS = Map.of(
-        "Lumbridge Cook... again", "Another Cook's"
+        "Lumbridge Cook... again", "Another Cook's",
+        "Skrach 'Bone Crusher' Uglogwee", "Skrach Uglogwee"
     );
 
     @Nullable

--- a/src/main/java/dinkplugin/util/QuestUtils.java
+++ b/src/main/java/dinkplugin/util/QuestUtils.java
@@ -37,10 +37,10 @@ import com.google.common.collect.ImmutableList;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,6 +52,9 @@ public class QuestUtils {
     private final Pattern QUEST_PATTERN_2 = Pattern.compile("'?(?<quest>.+?)'?(?: [Qq]uest)? (?<verb>[a-z]\\w+?ed)?(?: f.*?)?[!.]?$");
     private final Collection<String> RFD_TAGS = ImmutableList.of("Another Cook", "freed", "defeated", "saved");
     private final Collection<String> WORD_QUEST_IN_NAME_TAGS = ImmutableList.of("Another Cook", "Doric", "Heroes", "Legends", "Observatory", "Olaf", "Waterfall");
+    private final Map<String, String> QUEST_REPLACEMENTS = Map.of(
+        "Lumbridge Cook... again", "Another Cook's"
+    );
 
     @Nullable
     public String parseQuestWidget(final String text) {
@@ -62,6 +65,8 @@ public class QuestUtils {
         }
 
         String quest = matcher.group("quest");
+        quest = QUEST_REPLACEMENTS.getOrDefault(quest, quest);
+
         String verb = StringUtils.defaultString(matcher.group("verb"));
 
         if (verb.contains("kind of")) {

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -108,7 +108,7 @@ class QuestNotifierTest extends MockedNotifierTest {
         assertEquals("Recipe for Disaster - Another Cook's Quest", parseQuestWidget("You have assisted the Lumbridge Cook... again!"));
         assertEquals("Recipe for Disaster - Goblin Generals", parseQuestWidget("You have freed the Goblin Generals!"));
         assertEquals("Recipe for Disaster - Sir Amik Varze", parseQuestWidget("You have freed Sir Amik Varze!"));
-        assertEquals("Recipe for Disaster - Skrach 'Bone Crusher' Uglogwee", parseQuestWidget("You have freed Skrach 'Bone Crusher' Uglogwee!"));
+        assertEquals("Recipe for Disaster - Skrach Uglogwee", parseQuestWidget("You have freed Skrach 'Bone Crusher' Uglogwee!"));
         assertEquals("Recipe for Disaster", parseQuestWidget("You have completed Recipe for Disaster!"));
 
         assertEquals("Doric's Quest", parseQuestWidget("You have completed Doric's Quest!"));

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -6,11 +6,9 @@ import dinkplugin.message.NotificationType;
 import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.QuestNotificationData;
-import dinkplugin.util.QuestUtils;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -19,6 +17,7 @@ import static dinkplugin.util.QuestUtils.parseQuestWidget;
 import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.QUEST_COMPLETED_NAME_TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -111,6 +110,16 @@ class QuestNotifierTest extends MockedNotifierTest {
         assertEquals("Recipe for Disaster - Sir Amik Varze", parseQuestWidget("You have freed Sir Amik Varze!"));
         assertEquals("Recipe for Disaster - Skrach 'Bone Crusher' Uglogwee", parseQuestWidget("You have freed Skrach 'Bone Crusher' Uglogwee!"));
         assertEquals("Recipe for Disaster", parseQuestWidget("You have completed Recipe for Disaster!"));
+
+        assertEquals("Doric's Quest", parseQuestWidget("You have completed Doric's Quest!"));
+        assertEquals("Heroes Quest", parseQuestWidget("You have completed the Heroes' Quest!"));
+
+        assertEquals("Dragon Slayer II", parseQuestWidget("You have completed Dragon Slayer II!"));
+        assertEquals("Rag and Bone Man II", parseQuestWidget("You have completed Rag and Bone Man II!"));
+        assertEquals("Fairytale II - Cure a Queen", parseQuestWidget("You have completed Fairytale II - Cure a Queen!"));
+
+        assertNull(parseQuestWidget("You have... kind of... completed Hazeel Cult!"));
+        assertEquals("Hazeel Cult", parseQuestWidget("You have completed Hazeel Cult!"));
     }
 
     private static WidgetLoaded event(int id) {

--- a/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/QuestNotifierTest.java
@@ -6,15 +6,19 @@ import dinkplugin.message.NotificationType;
 import dinkplugin.message.templating.Replacements;
 import dinkplugin.message.templating.Template;
 import dinkplugin.notifiers.data.QuestNotificationData;
+import dinkplugin.util.QuestUtils;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
+import static dinkplugin.util.QuestUtils.parseQuestWidget;
 import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.QUEST_COMPLETED_NAME_TEXT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -97,6 +101,16 @@ class QuestNotifierTest extends MockedNotifierTest {
 
         // verify no message
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
+    @Test
+    void parseWidgets() {
+        assertEquals("Recipe for Disaster - Another Cook's Quest", parseQuestWidget("You have completed Another Cook's Quest!"));
+        assertEquals("Recipe for Disaster - Another Cook's Quest", parseQuestWidget("You have assisted the Lumbridge Cook... again!"));
+        assertEquals("Recipe for Disaster - Goblin Generals", parseQuestWidget("You have freed the Goblin Generals!"));
+        assertEquals("Recipe for Disaster - Sir Amik Varze", parseQuestWidget("You have freed Sir Amik Varze!"));
+        assertEquals("Recipe for Disaster - Skrach 'Bone Crusher' Uglogwee", parseQuestWidget("You have freed Skrach 'Bone Crusher' Uglogwee!"));
+        assertEquals("Recipe for Disaster", parseQuestWidget("You have completed Recipe for Disaster!"));
     }
 
     private static WidgetLoaded event(int id) {


### PR DESCRIPTION
Prefer `Another Cook's Quest` over `Lumbridge Cook... again` (widget text was changed a couple years ago)
https://oldschool.runescape.wiki/w/File:Another_Cook%27s_Quest_reward_scroll.png#filehistory

old quest name is still referenced in official widgets 
![image](https://github.com/pajlads/DinkPlugin/assets/8106344/4457382b-8108-4ac6-a41b-04ed38672714)
