### PR TITLE
fix: cancel queued notifications if notifier is concurrently disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Improve handling of queued notifications upon concurrent config changes. (#355)
+
 ## 1.6.4
 
 - Minor: Add task progress metadata for diary notifications. (#331)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -44,7 +44,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
-import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.loottracker.LootReceived;
@@ -124,12 +123,6 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onCommandExecuted(CommandExecuted event) {
         settingsManager.onCommand(event);
-    }
-
-    @Subscribe
-    public void onProfileChanged(ProfileChanged event) {
-        settingsManager.onProfileChanged(); // update player name filters
-        lootNotifier.init(); // reset item filters
     }
 
     @Subscribe

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -87,7 +87,7 @@ public class DinkPlugin extends Plugin {
 
     @Override
     protected void startUp() {
-        log.info("Started up Dink");
+        log.debug("Started up Dink");
         settingsManager.init();
         lootNotifier.init();
         levelNotifier.initLevels();
@@ -95,7 +95,7 @@ public class DinkPlugin extends Plugin {
 
     @Override
     protected void shutDown() {
-        log.info("Shutting down Dink");
+        log.debug("Shutting down Dink");
         this.resetNotifiers();
     }
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -44,6 +44,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
+import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.loottracker.LootReceived;
@@ -123,6 +124,12 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onCommandExecuted(CommandExecuted event) {
         settingsManager.onCommand(event);
+    }
+
+    @Subscribe
+    public void onProfileChanged(ProfileChanged event) {
+        settingsManager.onProfileChanged(); // update player name filters
+        lootNotifier.init(); // reset item filters
     }
 
     @Subscribe

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -153,10 +153,6 @@ public class SettingsManager {
         }
     }
 
-    void onProfileChanged() {
-        setFilteredNames(config.filteredNames());
-    }
-
     void onConfigChanged(ConfigChanged event) {
         String key = event.getKey();
         String value = event.getNewValue();

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -153,6 +153,10 @@ public class SettingsManager {
         }
     }
 
+    void onProfileChanged() {
+        setFilteredNames(config.filteredNames());
+    }
+
     void onConfigChanged(ConfigChanged event) {
         String key = event.getKey();
         String value = event.getNewValue();
@@ -279,9 +283,6 @@ public class SettingsManager {
             .map(String::toLowerCase)
             .forEach(filteredNames::add);
         log.debug("Updated RSN Filter List to: {}", filteredNames);
-
-        // clear any outdated notifier state
-        plugin.resetNotifiers();
     }
 
     /**

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -106,8 +106,11 @@ public class KillCountNotifier extends BaseNotifier {
         BossNotificationData data = this.data.get();
         if (data != null) {
             if (data.getBoss() != null) {
-                // once boss name has arrived, we notify at tick end (even if duration hasn't arrived)
-                handleKill(data);
+                // ensure notifier was not disabled during bad ticks wait period
+                if (isEnabled()) {
+                    // once boss name has arrived, we notify at tick end (even if duration hasn't arrived)
+                    handleKill(data);
+                }
                 reset();
             } else if (badTicks.incrementAndGet() > MAX_BAD_TICKS) {
                 // after receiving fight duration, allow up to 10 ticks for boss name to arrive.

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -96,7 +96,12 @@ public class LevelNotifier extends BaseNotifier {
         // We wait a couple extra ticks so we can ensure that we process all the levels of the previous tick
         if (ticks > 2) {
             ticksWaited.set(0);
-            attemptNotify();
+            // ensure notifier was not disabled during ticks waited
+            if (isEnabled()) {
+                attemptNotify();
+            } else {
+                levelledSkills.clear();
+            }
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -133,8 +133,13 @@ public class PetNotifier extends BaseNotifier {
         if (petName == null)
             return;
 
-        if (milestone != null || ticksWaited.incrementAndGet() > MAX_TICKS_WAIT)
-            this.handleNotify();
+        if (milestone != null || ticksWaited.incrementAndGet() > MAX_TICKS_WAIT) {
+            // ensure notifier was not disabled during wait ticks
+            if (isEnabled()) {
+                this.handleNotify();
+            }
+            this.reset();
+        }
     }
 
     public void reset() {
@@ -188,8 +193,6 @@ public class PetNotifier extends BaseNotifier {
             .thumbnailUrl(thumbnail)
             .type(NotificationType.PET)
             .build());
-
-        reset();
     }
 
     private static Optional<ParseResult> parseItemFromGameMessage(String message) {


### PR DESCRIPTION
Some notifiers delay sending notifications by a few ticks. This PR fixes some edge cases when config changes (or profile changes) occur *while* a notification is queued.

* When RSN filter changes, we clear all notifier state, even if the update is irrelevant for the current player name. This is overkill; we ought to keep notifier state (i.e., fire the queued notification) if not impacted by the change
* If notifier is disabled while a notification is queued, we ought to not fire the notification.

Fixing these (rare) edge cases is as simple as adding an extra `BaseNotifier#isEnabled` check when queued notification delay has expired (i.e., we're about to release the queued notification)
