### PR TITLE
feat: allow notifications on seasonal worlds to be ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Allow notifications on seasonal worlds to be ignored via advanced config. (#357)
+
 ## 1.6.4
 
 - Minor: Add task progress metadata for diary notifications. (#331)

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -349,6 +349,17 @@ public interface DinkPluginConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "ignoreSeasonalWorlds",
+        name = "Ignore Seasonal Worlds",
+        description = "Whether to suppress notifications that occur on seasonal worlds like Leagues",
+        position = 1015,
+        section = advancedSection
+    )
+    default boolean ignoreSeasonal() {
+        return false;
+    }
+
+    @ConfigItem(
         keyName = "discordWebhook", // do not rename; would break old configs
         name = "Primary Webhook URLs",
         description = "The default webhook URL to send notifications to, if no override is specified.<br/>" +

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -253,10 +253,11 @@ public class DiscordMessageHandler {
     private NotificationBody<?> injectThreadName(HttpUrl url, NotificationBody<?> mBody, boolean force) {
         Collection<String> queryParams = url.queryParameterNames();
         if (force || (queryParams.contains("forum") && !queryParams.contains("thread_id"))) {
+            String type = mBody.isSeasonalWorld() ? "Seasonal - " + mBody.getType().getTitle() : mBody.getType().getTitle();
             String threadName = Template.builder()
                 .template(config.threadNameTemplate())
                 .replacementBoundary("%")
-                .replacement("%TYPE%", Replacements.ofText(mBody.getType().getTitle()))
+                .replacement("%TYPE%", Replacements.ofText(type))
                 .replacement("%MESSAGE%", mBody.getText())
                 .replacement("%USERNAME%", Replacements.ofText(mBody.getPlayerName()))
                 .build()
@@ -345,7 +346,7 @@ public class DiscordMessageHandler {
             Embed.builder()
                 .author(author)
                 .color(Utils.PINK)
-                .title(type.getTitle())
+                .title(body.isSeasonalWorld() ? "[Seasonal] " + type.getTitle() : type.getTitle())
                 .description(Utils.truncate(body.getText().evaluate(config.discordRichEmbeds()), Embed.MAX_DESCRIPTION_LENGTH))
                 .image(screenshot ? new Embed.UrlEmbed("attachment://" + type.getScreenshot()) : null)
                 .thumbnail(new Embed.UrlEmbed(thumbnail))

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -12,6 +12,7 @@ import dinkplugin.util.Utils;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.WorldType;
 import net.runelite.api.clan.ClanChannel;
 import net.runelite.api.clan.ClanID;
 import net.runelite.api.widgets.Widget;
@@ -217,6 +218,10 @@ public class DiscordMessageHandler {
         }
 
         NotificationBody.NotificationBodyBuilder<?> builder = mBody.toBuilder();
+
+        if (!config.ignoreSeasonal()) {
+            builder.seasonalWorld(client.getWorldType().contains(WorldType.SEASONAL));
+        }
 
         if (config.sendDiscordUser()) {
             builder.discordUser(DiscordProfile.of(discordService.getCurrentUser()));

--- a/src/main/java/dinkplugin/message/NotificationBody.java
+++ b/src/main/java/dinkplugin/message/NotificationBody.java
@@ -37,6 +37,7 @@ public class NotificationBody<T extends NotificationData> {
     String clanName;
     @Nullable
     String groupIronClanName;
+    boolean seasonalWorld;
     @Nullable
     T extra;
     @NotNull

--- a/src/main/java/dinkplugin/notifiers/BaseNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/BaseNotifier.java
@@ -6,9 +6,11 @@ import dinkplugin.message.DiscordMessageHandler;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.util.WorldUtils;
 import net.runelite.api.Client;
+import net.runelite.api.WorldType;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 public abstract class BaseNotifier {
 
@@ -25,7 +27,11 @@ public abstract class BaseNotifier {
     private DiscordMessageHandler messageHandler;
 
     public boolean isEnabled() {
-        return !WorldUtils.isIgnoredWorld(client.getWorldType()) && settingsManager.isNamePermitted(client.getLocalPlayer().getName());
+        Set<WorldType> world = client.getWorldType();
+        if ((config.ignoreSeasonal() && world.contains(WorldType.SEASONAL)) || WorldUtils.isIgnoredWorld(world)) {
+            return false;
+        }
+        return settingsManager.isNamePermitted(client.getLocalPlayer().getName());
     }
 
     protected abstract String getWebhookUrl();

--- a/src/main/java/dinkplugin/notifiers/BaseNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/BaseNotifier.java
@@ -28,7 +28,10 @@ public abstract class BaseNotifier {
 
     public boolean isEnabled() {
         Set<WorldType> world = client.getWorldType();
-        if ((config.ignoreSeasonal() && world.contains(WorldType.SEASONAL)) || WorldUtils.isIgnoredWorld(world)) {
+        if (config.ignoreSeasonal() && world.contains(WorldType.SEASONAL)) {
+            return false;
+        }
+        if (WorldUtils.isIgnoredWorld(world)) {
             return false;
         }
         return settingsManager.isNamePermitted(client.getLocalPlayer().getName());


### PR DESCRIPTION
Work towards #356 (adds `seasonalWorld` to notification metadata)