### PR TITLE
Release Dink 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.6.5
+
 - Minor: Allow notifications on seasonal worlds to be ignored via advanced config. (#357)
 - Minor: Prefer historical name for first Recipe for Disaster quest. (#352)
 - Minor: Include owned pets in login notification metadata. (#347)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.6.4"
+version = "1.6.5"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
I'm not going to re-write the description for 1.6.4* I'll just stick this in the PR body

`1.6.5`: fixed Galvek rematch deaths being handled incorrectly, added a few more pieces of information to LOGIN notifications, migrated widget usage to the new API, and first steps for Leagues handling