### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.7.0
+
 - Major: Add leagues notifier for areas, relics, and tasks. (#366)
 
 ## 1.6.5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.6.5"
+version = "1.7.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.7.0 adds a new notifier for Leagues IV to capture task completions, area unlocks, and relic selections. 
