### PR TITLE
chore: update `warnForGameSetting` logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.1
 
 - Bugfix: Report correct remaining tasks until next area unlock in Leagues notifications. (#369)
+- Dev: Moved `warnForGameSetting` logging down to `log.debug` 
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.7.1
 
 - Bugfix: Report correct remaining tasks until next area unlock in Leagues notifications. (#369)
-- Dev: Moved `warnForGameSetting` logging down to `log.debug` 
+- Dev: Moved `warnForGameSetting` logging down to `log.debug`. (#372)
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Dev: Moved `warnForGameSetting` logging down to `log.debug`. (#372)
+- Dev: Change game setting warning logs to debug level. (#372)
 
 ## 1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Unreleased
 
+- Dev: Moved `warnForGameSetting` logging down to `log.debug`. (#372)
+
 ## 1.7.1
 
 - Bugfix: Report correct remaining tasks until next area unlock in Leagues notifications. (#369)
-- Dev: Moved `warnForGameSetting` logging down to `log.debug`. (#372)
 
 ## 1.7.0
 

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -268,7 +268,7 @@ public class SettingsManager {
         if (isSettingsOpen(client)) {
             plugin.addChatWarning(message);
         } else {
-            log.warn(message);
+            log.debug(message);
         }
     }
 


### PR DESCRIPTION
Often would happen when hopping to a "new" account, while using old profile. Since you never interacted with any of the settings, the chat message would never fire and would just cry all over your logs.

In almost all cases we know what the problem is, so the warn logging is no longer necessary.

idk what title to give this change tho