### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.7.2
+
 - Dev: Utilize runelite event for unsired loot instead of custom widget handler (#375).
 
 ## 1.7.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.7.1"
+version = "1.7.2"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Removes custom handling for unsired, as the native loot tracker will handle this in the next Runelite version.