### PR TITLE
fix: avoid level initialization before first StatChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: Avoid erroneous level notification on login when initial data is delayed. (#383)
 - Bugfix: Ensure diary notifications below the configured minimum difficulty are not sent. (#382)
 - Bugfix: Update set of items that are never kept on dangerous deaths. (#364)
 - Bugfix: Don't report inaccurate completed collections count, when character summary tab was not selected. (#374)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -95,7 +95,6 @@ public class DinkPlugin extends Plugin {
         log.debug("Started up Dink");
         settingsManager.init();
         lootNotifier.init();
-        levelNotifier.initLevels();
     }
 
     @Override

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.runelite.api.Experience.MAX_REAL_LEVEL;
@@ -33,13 +34,14 @@ import static net.runelite.api.Experience.MAX_REAL_LEVEL;
 @Singleton
 public class LevelNotifier extends BaseNotifier {
     public static final int LEVEL_FOR_MAX_XP = Experience.MAX_VIRT_LEVEL + 1; // 127
-    private static final int INIT_CLIENT_TICKS = 50; // 1000ms
+    private static final int INIT_GAME_TICKS = 25; // 15s
     private static final String COMBAT_NAME = "Combat";
     private static final Set<String> COMBAT_COMPONENTS;
     private final BlockingQueue<String> levelledSkills = new ArrayBlockingQueue<>(Skill.values().length + 1);
     private final Map<String, Integer> currentLevels = new HashMap<>();
     private final AtomicInteger ticksWaited = new AtomicInteger();
     private final AtomicInteger initTicks = new AtomicInteger();
+    private final AtomicBoolean shouldInit = new AtomicBoolean();
 
     @Inject
     private ClientThread clientThread;
@@ -49,42 +51,35 @@ public class LevelNotifier extends BaseNotifier {
         return config.levelWebhook();
     }
 
-    public void initLevels() {
-        // initTicks == 0 => set initTicks to INIT_CLIENT_TICKS & schedule level lookup
-        if (initTicks.getAndUpdate(i -> i <= 0 ? INIT_CLIENT_TICKS : i) > 0)
-            return; // init task is already queued
-
-        clientThread.invokeLater(() -> {
-            if (client.getGameState() != GameState.LOGGED_IN)
-                return false;
-
-            if (initTicks.updateAndGet(i -> i - 1) > 0)
-                return false; // still need to wait more ticks
-
-            for (Skill skill : Skill.values()) {
-                int level = client.getRealSkillLevel(skill); // O(1)
-                if (level >= MAX_REAL_LEVEL) {
-                    level = getLevel(client.getSkillExperience(skill));
-                }
-                currentLevels.put(skill.getName(), level);
+    private void initLevels() {
+        for (Skill skill : Skill.values()) {
+            int level = client.getRealSkillLevel(skill); // O(1)
+            if (level >= MAX_REAL_LEVEL) {
+                level = getLevel(client.getSkillExperience(skill));
             }
-            currentLevels.put(COMBAT_NAME, calculateCombatLevel());
-            log.debug("Initialized current skill levels: {}", currentLevels);
-            return true;
-        });
+            currentLevels.put(skill.getName(), level);
+        }
+        currentLevels.put(COMBAT_NAME, calculateCombatLevel());
+        initTicks.set(0);
+        log.debug("Initialized current skill levels: {}", currentLevels);
     }
 
     public void reset() {
-        clientThread.invoke(() -> {
-            currentLevels.clear();
-            levelledSkills.clear();
-            ticksWaited.set(0);
-        });
+        shouldInit.set(false);
+        initTicks.set(0);
+        levelledSkills.clear();
+        ticksWaited.set(0);
+        clientThread.invoke(currentLevels::clear);
     }
 
     public void onTick() {
-        if (currentLevels.isEmpty()) {
+        if (shouldInit.getAndSet(false)) {
             initLevels();
+            return;
+        }
+
+        if (currentLevels.isEmpty()) {
+            shouldInit.compareAndSet(false, initTicks.incrementAndGet() > INIT_GAME_TICKS);
             return;
         }
 
@@ -122,7 +117,7 @@ public class LevelNotifier extends BaseNotifier {
         Integer previousLevel = currentLevels.put(skill, virtualLevel);
 
         if (previousLevel == null) {
-            initLevels();
+            shouldInit.set(true);
             return;
         }
 

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -62,6 +62,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         plugin.onStatChanged(new StatChanged(Skill.HITPOINTS, 1200, 10, 10));
         plugin.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
         plugin.onStatChanged(new StatChanged(Skill.SLAYER, 9_800_000, 96, 96));
+        notifier.onTick();
     }
 
     @Test


### PR DESCRIPTION
Performs currentLevels initialization on the tick after the first `StatChanged` (or 15 seconds after login if `StatChanged` doesn't occur). 

Previously there could be an edge case where jagex sends character levels on the second game tick (t=1200ms), but we would've initialized at 50 client ticks (t=1000ms), so it would've looked like many level-ups occurred at once

This approach is robust to initial `StatChanged` events being sent on any game tick within the first 15 seconds after login
