### PR TITLE
Separate Jad challenges from Inferno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Allow customization of which safe deaths can trigger notifications. (#363)
+- Minor: Allow customization of which safe deaths can trigger notifications. (#363, #384)
 - Bugfix: Ensure diary notifications below the configured minimum difficulty are not sent. (#382)
 - Bugfix: Update set of items that are never kept on dangerous deaths. (#364)
 - Bugfix: Don't report inaccurate completed collections count, when character summary tab was not selected. (#374)

--- a/src/main/java/dinkplugin/domain/ExceptionalDeath.java
+++ b/src/main/java/dinkplugin/domain/ExceptionalDeath.java
@@ -10,8 +10,8 @@ public enum ExceptionalDeath {
     COX("Chambers of Xeric"),
     FIGHT_CAVE("Fight Caves"),
     INFERNO("Inferno"),
-    TOA("Tombs of Amascut"),
-    JAD_CHALLENGES("Jad challenges");
+    JAD_CHALLENGES("Jad challenges"),
+    TOA("Tombs of Amascut");
 
     private final String displayName;
 

--- a/src/main/java/dinkplugin/domain/ExceptionalDeath.java
+++ b/src/main/java/dinkplugin/domain/ExceptionalDeath.java
@@ -10,7 +10,8 @@ public enum ExceptionalDeath {
     COX("Chambers of Xeric"),
     FIGHT_CAVE("Fight Caves"),
     INFERNO("Inferno"),
-    TOA("Tombs of Amascut");
+    TOA("Tombs of Amascut"),
+    JAD_CHALLENGES("Jad challenges");
 
     private final String displayName;
 

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -116,7 +116,7 @@ public class WorldUtils {
      * The in-game region is the same as the inferno, but a varp value is different
      */
     public boolean isJadChallenges(Client client, int regionId) {
-        return regionId == INFERNO_REGION && client.getVarpValue(INSIDE_RAID_OR_CHALLENGE) == 1001;
+        return regionId == INFERNO_REGION && client.getVarpValue(INSIDE_RAID_OR_CHALLENGE) > 0;
     }
 
     public boolean isLastManStanding(Client client) {

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -9,6 +9,7 @@ import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.WorldType;
 import net.runelite.api.annotations.Varbit;
+import net.runelite.api.annotations.Varp;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
@@ -43,6 +44,11 @@ public class WorldUtils {
      * @see <a href="https://oldschool.runescape.wiki/w/RuneScape:Varbit/6104">Wiki</a>
      */
     private final @Varbit int DRAGON_SLAYER_II_PROGRESS = 6104;
+
+    /**
+     * @see <a href="https://oldschool.runescape.wiki/w/RuneScape:Varplayer/2926">Wiki</a>
+     */
+    private final @Varp int INSIDE_RAID_OR_CHALLENGE = 2926;
 
     /**
      * @see <a href="https://chisel.weirdgloop.org/varbs/display?varbit=6104#ChangeFrequencyTitle">Chisel</a>
@@ -101,8 +107,16 @@ public class WorldUtils {
         return GAUNTLET_REGIONS.contains(regionId);
     }
 
-    public boolean isInferno(int regionId) {
-        return regionId == INFERNO_REGION;
+    public boolean isInferno(Client client, int regionId) {
+        return regionId == INFERNO_REGION && client.getVarpValue(INSIDE_RAID_OR_CHALLENGE) == 0;
+    }
+
+    /**
+     * Checks whether the player is within TzHaar-Ket-Rak's Challenges
+     * The in-game region is the same as the inferno, but a varp value is different
+     */
+    public boolean isJadChallenges(Client client, int regionId) {
+        return regionId == INFERNO_REGION && client.getVarpValue(INSIDE_RAID_OR_CHALLENGE) == 1001;
     }
 
     public boolean isLastManStanding(Client client) {
@@ -166,8 +180,12 @@ public class WorldUtils {
             return checkException(Utils.getAccountType(client) == AccountType.HARDCORE_GROUP_IRONMAN, exceptions, ExceptionalDeath.COX);
         }
 
-        if (isInferno(regionId)) {
+        if (isInferno(client, regionId)) {
             return checkException(Utils.getAccountType(client) == AccountType.HARDCORE_GROUP_IRONMAN, exceptions, ExceptionalDeath.INFERNO);
+        }
+
+        if (isJadChallenges(client, regionId)) {
+            return checkException(Utils.getAccountType(client) == AccountType.HARDCORE_GROUP_IRONMAN, exceptions, ExceptionalDeath.JAD_CHALLENGES);
         }
 
         if (isTzHaarFightCave(regionId)) {


### PR DESCRIPTION
Relies on https://oldschool.runescape.wiki/w/RuneScape:Varplayer/2926 to check whether the player is inside the Jad challenge room since the region is the same

I have tested this in-game and it works as expected.
I have not changed any defaults on purpose, as I think deaths in this challenge may be a bit too frequent to warrant death notifications by default.

Changelog entry change is up for debate, as is naming