### PR TITLE
feat: add tob as exceptional safe death that can trigger a notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Major: Add notifier to capture trades with other players. (#361)
 - Minor: Add loot notifier setting that redirects pk loot to the pk notifier override url. (#353)
-- Minor: Allow customization of which safe deaths can trigger notifications. (#363, #384)
+- Minor: Allow customization of which safe deaths can trigger notifications. (#363, #384, #385)
 - Bugfix: Avoid erroneous level notification on login when initial data is delayed. (#383)
 - Bugfix: Ensure diary notifications below the configured minimum difficulty are not sent. (#382)
 - Bugfix: Update set of items that are never kept on dangerous deaths. (#364)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -258,6 +258,7 @@ public class DinkPlugin extends Plugin {
     @Subscribe
     public void onScriptPreFired(ScriptPreFired event) {
         collectionNotifier.onScript(event.getScriptId());
+        deathNotifier.onScript(event);
     }
 
     @Subscribe(priority = 1) // run before the base loot tracker plugin

--- a/src/main/java/dinkplugin/domain/ExceptionalDeath.java
+++ b/src/main/java/dinkplugin/domain/ExceptionalDeath.java
@@ -11,8 +11,8 @@ public enum ExceptionalDeath {
     FIGHT_CAVE("Fight Caves"),
     INFERNO("Inferno"),
     JAD_CHALLENGES("Jad challenges"),
-    TOA("Tombs of Amascut"),
-    TOB("Theatre of Blood");
+    TOB("Theatre of Blood"),
+    TOA("Tombs of Amascut");
 
     private final String displayName;
 

--- a/src/main/java/dinkplugin/domain/ExceptionalDeath.java
+++ b/src/main/java/dinkplugin/domain/ExceptionalDeath.java
@@ -11,7 +11,8 @@ public enum ExceptionalDeath {
     FIGHT_CAVE("Fight Caves"),
     INFERNO("Inferno"),
     JAD_CHALLENGES("Jad challenges"),
-    TOA("Tombs of Amascut");
+    TOA("Tombs of Amascut"),
+    TOB("Theatre of Blood");
 
     private final String displayName;
 

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -25,6 +25,7 @@ import net.runelite.api.Prayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.ScriptPreFired;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.NPCManager;
 import org.apache.commons.lang3.ArrayUtils;
@@ -57,6 +58,13 @@ public class DeathNotifier extends BaseNotifier {
     private static final String ATTACK_OPTION = "Attack";
 
     private static final String TOA_DEATH_MSG = "You failed to survive the Tombs of Amascut";
+
+    private static final String TOB_DEATH_MSG = "Your party has failed";
+
+    /**
+     * @see <a href="https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bclientscript,tob_hud_portal%5D.cs2">CS2 Reference</a>
+     */
+    private static final int TOB_HUB_PORTAL_SCRIPT = 2307;
 
     /**
      * Checks whether the actor is alive and interacting with the specified player.
@@ -122,6 +130,21 @@ public class DeathNotifier extends BaseNotifier {
             // https://github.com/pajlads/DinkPlugin/issues/316
             // though, hardcore (group) ironmen just use the normal ActorDeath trigger for TOA
             handleNotify(Danger.DANGEROUS);
+        }
+    }
+
+    public void onScript(ScriptPreFired event) {
+        if (event.getScriptId() == TOB_HUB_PORTAL_SCRIPT && event.getScriptEvent() != null &&
+            config.deathIgnoreSafe() && !config.deathSafeExceptions().contains(ExceptionalDeath.TOB) &&
+            !Utils.getAccountType(client).isHardcore() && isEnabled()) {
+            Object[] args = event.getScriptEvent().getArguments();
+            if (args != null && args.length > 1) {
+                Object text = args[1];
+                if (text instanceof String && ((String) text).contains(TOB_DEATH_MSG)) {
+                    // https://oldschool.runescape.wiki/w/Theatre_of_Blood#Death_within_the_Theatre
+                    handleNotify(Danger.DANGEROUS);
+                }
+            }
         }
     }
 

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -34,6 +34,7 @@ public class WorldUtils {
     private final Set<Integer> POH_REGIONS = ImmutableSet.of(7257, 7513, 7514, 7769, 7770, 8025, 8026);
     private final Set<Integer> SOUL_REGIONS = ImmutableSet.of(8493, 8748, 8749, 9005);
     private final Set<Integer> TOA_REGIONS = ImmutableSet.of(14160, 14162, 14164, 14674, 14676, 15184, 15186, 15188, 15696, 15698, 15700);
+    private final Set<Integer> TOB_REGIONS = ImmutableSet.of(12611, 12612, 12613, 12867, 12869, 13122, 13123, 13125, 13379);
     private final int BURTHORPE_REGION = 8781;
     private final int INFERNO_REGION = 9043;
     private final int NMZ_REGION = 9033;
@@ -152,6 +153,10 @@ public class WorldUtils {
         return TOA_REGIONS.contains(regionId);
     }
 
+    public boolean isBloodTheatre(int regionId) {
+        return TOB_REGIONS.contains(regionId);
+    }
+
     public boolean isTzHaarFightCave(int regionId) {
         return regionId == TZHAAR_CAVE;
     }
@@ -174,6 +179,13 @@ public class WorldUtils {
             // the real TOA death is detected via game message in death notifier
             // However: any TOA death is still dangerous for hardcore (group) ironmen
             return checkException(Utils.getAccountType(client).isHardcore(), exceptions, ExceptionalDeath.TOA);
+        }
+
+        if (isBloodTheatre(regionId)) {
+            // ToB is another dangerous activity, but the whole party needs to wipe for it to be a dangerous event
+            // So we use HUD text to detect the real tob death in the notifier itself
+            // However: any TOB death is still dangerous for hardcore (group) ironmen
+            return checkException(Utils.getAccountType(client).isHardcore(), exceptions, ExceptionalDeath.TOB);
         }
 
         if (isChambersOfXeric(regionId)) {

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -153,7 +153,7 @@ public class WorldUtils {
         return TOA_REGIONS.contains(regionId);
     }
 
-    public boolean isBloodTheatre(int regionId) {
+    public boolean isTheatreOfBlood(int regionId) {
         return TOB_REGIONS.contains(regionId);
     }
 
@@ -181,7 +181,7 @@ public class WorldUtils {
             return checkException(Utils.getAccountType(client).isHardcore(), exceptions, ExceptionalDeath.TOA);
         }
 
-        if (isBloodTheatre(regionId)) {
+        if (isTheatreOfBlood(regionId)) {
             // ToB is another dangerous activity, but the whole party needs to wipe for it to be a dangerous event
             // So we use HUD text to detect the real tob death in the notifier itself
             // However: any TOB death is still dangerous for hardcore (group) ironmen


### PR DESCRIPTION
TOB death is only dangerous if hardcore ironman or the full party wipes. We now correctly consider TOB deaths to be safe or dangerous (and the notifier can be configured to dink on safe tob deaths as well). Also: all entry mode tob deaths are safe (so the `Your party has failed.` hud text never appears, as expected)

Follow-up to #363
