### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.8.0
+
 - Major: Add notifier to capture trades with other players. (#361)
 - Minor: Add loot notifier setting that redirects pk loot to the pk notifier override url. (#353)
 - Minor: Allow customization of which safe deaths can trigger notifications. (#363, #384, #385)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.7.2"
+version = "1.8.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.8.0 adds a new notifier to capture player trades, fixes some bugs, and allows customization of which safe deaths should trigger notifications.