### PR TITLE
refactor: use new runelite method for widget id packing

### DIFF
--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -18,6 +18,7 @@ import net.runelite.api.clan.ClanChannel;
 import net.runelite.api.clan.ClanID;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.ui.DrawManager;
@@ -62,7 +63,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Singleton
 public class DiscordMessageHandler {
-    public static final @Component int PRIVATE_CHAT_WIDGET = Utils.packWidget(InterfaceID.PRIVATE_CHAT, 0);
+    public static final @Component int PRIVATE_CHAT_WIDGET = WidgetUtil.packComponentId(InterfaceID.PRIVATE_CHAT, 0);
 
     private final Gson gson;
     private final Client client;
@@ -296,7 +297,7 @@ public class DiscordMessageHandler {
             drawManager.requestNextFrameListener(img -> {
                 // unhide any widgets we hid (scheduled for client thread)
                 Utils.unhideWidget(chatHidden, client, clientThread, ComponentID.CHATBOX_FRAME);
-                Utils.unhideWidget(whispersHidden, client, clientThread, Utils.packWidget(InterfaceID.PRIVATE_CHAT, 0));
+                Utils.unhideWidget(whispersHidden, client, clientThread, PRIVATE_CHAT_WIDGET);
 
                 // resolve future on separate thread
                 executor.execute(() -> future.complete(img));

--- a/src/main/java/dinkplugin/util/Utils.java
+++ b/src/main/java/dinkplugin/util/Utils.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.api.annotations.Component;
-import net.runelite.api.annotations.Interface;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.util.ColorUtil;
@@ -192,17 +191,6 @@ public class Utils {
             default:
                 return null;
         }
-    }
-
-    /**
-     * @param groupId the {@link Interface}
-     * @param childId the child id
-     * @return the corresponding {@link Component}
-     */
-    @Component
-    @SuppressWarnings("MagicConstant")
-    public int packWidget(@Interface int groupId, int childId) {
-        return groupId << 16 | childId;
     }
 
     public static boolean hideWidget(boolean shouldHide, Client client, @Component int info) {


### PR DESCRIPTION
Added in https://github.com/runelite/runelite/commit/e5de4d49f534ecfab1976bfe42b170a9f7fb439f (was not initially present when we migrated to new widget api)
