### PR TITLE
refactor: avoid hardcoding coin item ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Dynamically obtain coin item variations. (#398)
+
 ## 1.8.1
 
 - Dev: Changed the plugin icon to a Christmas version. (#393)

--- a/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GroupStorageNotifier.java
@@ -245,8 +245,8 @@ public class GroupStorageNotifier extends BaseNotifier {
      */
     private int getItemId(Item item) {
         int id = item.getId();
-        if (id == ItemID.COINS || id == ItemID.COINS_8890 || id == ItemID.COINS_6964)
-            return ItemID.COINS_995; // use single ID for all coins
+        if (ItemUtils.COIN_VARIATIONS.contains(id))
+            return ItemID.COINS; // use single ID for all coins
         return itemManager.canonicalize(id); // un-noted, un-placeholdered, un-worn
     }
 

--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -12,14 +12,17 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
+import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.util.QuantityFormatter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +39,8 @@ import static net.runelite.api.ItemID.*;
 public class ItemUtils {
 
     final String ITEM_CACHE_BASE_URL = "https://static.runelite.net/cache/item/";
+
+    public final Collection<Integer> COIN_VARIATIONS = new HashSet<>(ItemVariationMapping.getVariations(ItemID.COINS));
 
     private final Set<Integer> NEVER_KEPT_ITEMS = ImmutableSet.of(
         CLUE_BOX, LOOTING_BAG, FLAMTAER_BAG, JAR_GENERATOR,

--- a/src/test/java/dinkplugin/UtilsTest.java
+++ b/src/test/java/dinkplugin/UtilsTest.java
@@ -1,6 +1,8 @@
 package dinkplugin;
 
 import dinkplugin.util.ItemUtils;
+import net.runelite.api.ItemID;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,6 +19,15 @@ import net.runelite.client.game.ItemStack;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UtilsTest {
+
+    @Test
+    void coinVariations() {
+        assertTrue(ItemUtils.COIN_VARIATIONS.contains(ItemID.COINS));
+        assertTrue(ItemUtils.COIN_VARIATIONS.contains(ItemID.COINS_995));
+        assertTrue(ItemUtils.COIN_VARIATIONS.contains(ItemID.COINS_6964));
+        assertTrue(ItemUtils.COIN_VARIATIONS.contains(ItemID.COINS_8890));
+    }
+
     @ParameterizedTest(name = "Item stack should be reduced {0}")
     @ArgumentsSource(ItemStackReductionProvider.class)
     void itemStackShouldBeReduced(Collection<ItemStack> input, Collection<ItemStack> reduced) {

--- a/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/GroupStorageNotifierTest.java
@@ -62,7 +62,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
             .thenReturn("%USERNAME% has deposited:\n%DEPOSITED%\n\n%USERNAME% has withdrawn:\n%WITHDRAWN%");
 
         // init item mocks
-        mockItem(ItemID.COINS_995, 1, "Coins");
+        mockItem(ItemID.COINS, 1, "Coins");
         mockItem(ItemID.OPAL, OPAL_PRICE, "Opal");
         mockItem(ItemID.RUBY, RUBY_PRICE, "Ruby");
         mockItem(ItemID.TUNA, TUNA_PRICE, "Tuna");
@@ -147,7 +147,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         // verify notification message
         GroupStorageNotificationData extra = new GroupStorageNotificationData(
             Collections.emptyList(),
-            Collections.singletonList(new SerializedItemStack(ItemID.COINS_995, 900, 1, "Coins")),
+            Collections.singletonList(new SerializedItemStack(ItemID.COINS, 900, 1, "Coins")),
             -900,
             GROUP_NAME,
             true
@@ -173,7 +173,7 @@ class GroupStorageNotifierTest extends MockedNotifierTest {
         // verify notification message
         GroupStorageNotificationData extra = new GroupStorageNotificationData(
             Collections.emptyList(),
-            Collections.singletonList(new SerializedItemStack(ItemID.COINS_995, 800, 1, "Coins")),
+            Collections.singletonList(new SerializedItemStack(ItemID.COINS, 800, 1, "Coins")),
             -800,
             GROUP_NAME,
             true


### PR DESCRIPTION
Avoids plugin failing to compile if jagex ever changes these item ids
