### PR TITLE
feat: add chat command to obtain dink player hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Add chat command to obtain the player's dink hash. (#408)
+
 ## 1.8.4
 
 - Minor: Fire loot notification for PK loot chests with sufficiently high total value. (#417)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Note: There is no undo button for this command, so consider making a backup of y
 Warning: If you import override URLs for a notifier (that previously did not have any overrides), this will result in the plugin no longer sending messages from that notifier to your old primary URLs.
 As such, you can manually add your primary URLs to the newly populated override URL boxes so that notifications are still sent to the old primary URLs.
 
+### Get your Dink Hash via `::dinkhash`
+
+Dink notification metadata includes a player hash that custom webhook servers can utilize to uniquely identify players (persistent across name changes).
+
+You can obtain your dink hash via the `::dinkhash` chat command. Feel free to provide this value to third-party services that may request it.
+
 ### Get Current Region ID via `::dinkregion`
 
 The death notifier allows you to customize any region that should be ignored.

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -164,9 +164,9 @@ public class SettingsManager {
             CompletableFuture.completedFuture(client.getAccountHash())
                 .thenApplyAsync(Utils::dinkHash)
                 .thenCompose(Utils::copyToClipboard)
-                .thenRun(() -> plugin.addChatSuccess("Copied player dink hash to clipboard"))
+                .thenRun(() -> plugin.addChatSuccess("Copied your dink hash to clipboard"))
                 .exceptionally(t -> {
-                    plugin.addChatWarning("Failed to copy player dink hash to clipboard");
+                    plugin.addChatWarning("Failed to copy your dink hash to clipboard");
                     return null;
                 });
         } else if ("DinkRegion".equalsIgnoreCase(cmd)) {

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -149,6 +150,15 @@ public class SettingsManager {
             }
 
             exportConfig(includeKey);
+        } else if ("DinkHash".equalsIgnoreCase(cmd)) {
+            CompletableFuture.completedFuture(client.getAccountHash())
+                .thenApplyAsync(Utils::dinkHash)
+                .thenCompose(Utils::copyToClipboard)
+                .thenRun(() -> plugin.addChatSuccess("Copied player dink hash to clipboard"))
+                .exceptionally(t -> {
+                    plugin.addChatWarning("Failed to copy player dink hash to clipboard");
+                    return null;
+                });
         }
     }
 


### PR DESCRIPTION
Add `::dinkhash` command - can be useful for folks creating custom webhook handlers that want to allowlist certain accounts
