### PR TITLE
chore: disable leagues notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Include Scurrius pet name in pet notifications. (#410)
 - Bugfix: Update death safe exceptions on config import from clipboard. (#406)
+- Dev: Disable leagues notifier. (#411)
 
 ## 1.8.2
 

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -10,7 +10,6 @@ import dinkplugin.notifiers.GambleNotifier;
 import dinkplugin.notifiers.GrandExchangeNotifier;
 import dinkplugin.notifiers.GroupStorageNotifier;
 import dinkplugin.notifiers.KillCountNotifier;
-import dinkplugin.notifiers.LeaguesNotifier;
 import dinkplugin.notifiers.LevelNotifier;
 import dinkplugin.notifiers.LootNotifier;
 import dinkplugin.notifiers.MetaNotifier;
@@ -86,7 +85,6 @@ public class DinkPlugin extends Plugin {
     private @Inject PlayerKillNotifier pkNotifier;
     private @Inject GroupStorageNotifier groupStorageNotifier;
     private @Inject GrandExchangeNotifier grandExchangeNotifier;
-    private @Inject LeaguesNotifier leaguesNotifier;
     private @Inject MetaNotifier metaNotifier;
     private @Inject TradeNotifier tradeNotifier;
 
@@ -207,7 +205,6 @@ public class DinkPlugin extends Plugin {
                 combatTaskNotifier.onGameMessage(chatMessage);
                 deathNotifier.onGameMessage(chatMessage);
                 speedrunNotifier.onGameMessage(chatMessage);
-                leaguesNotifier.onGameMessage(chatMessage);
                 break;
 
             case FRIENDSCHATNOTIFICATION:

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -164,12 +164,14 @@ public interface DinkPluginConfig extends Config {
     )
     String tradeSection = "Player Trades";
 
+    /*
     @ConfigSection(
         name = "Leagues",
         description = "Settings for notifying when you complete league tasks, unlock areas, and redeem relics",
         position = 200,
         closedByDefault = true
     )
+     */
     String leaguesSection = "Leagues";
 
     @ConfigSection(
@@ -372,8 +374,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "ignoreSeasonalWorlds",
         name = "Ignore Seasonal Worlds",
-        description = "Whether to suppress notifications that occur on seasonal worlds like Leagues.<br/>" +
-            "Note: the Leagues-specific notifier uses an independent config toggle",
+        description = "Whether to suppress notifications that occur on seasonal worlds like Leagues.",
         position = 1015,
         section = advancedSection
     )
@@ -585,7 +586,8 @@ public interface DinkPluginConfig extends Config {
         description = "If non-empty, Leagues messages are sent to this URL, instead of the primary URL.<br/>" +
             "Note: this only applies to the Leagues notifier, not every notifier in a seasonal world",
         position = -1,
-        section = webhookSection
+        section = webhookSection,
+        hidden = true
     )
     default String leaguesWebhook() {
         return "";
@@ -1783,7 +1785,8 @@ public interface DinkPluginConfig extends Config {
         name = "Enable Leagues",
         description = "Enable notifications upon various leagues events",
         position = 200,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default boolean notifyLeagues() {
         return false;
@@ -1794,7 +1797,8 @@ public interface DinkPluginConfig extends Config {
         name = "Send Image",
         description = "Send image with the notification",
         position = 201,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default boolean leaguesSendImage() {
         return true;
@@ -1805,7 +1809,8 @@ public interface DinkPluginConfig extends Config {
         name = "Send Area Unlocks",
         description = "Send notifications upon area unlocks",
         position = 202,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default boolean leaguesAreaUnlock() {
         return true;
@@ -1816,7 +1821,8 @@ public interface DinkPluginConfig extends Config {
         name = "Send Relic Unlocks",
         description = "Send notifications upon relic unlocks",
         position = 203,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default boolean leaguesRelicUnlock() {
         return true;
@@ -1827,7 +1833,8 @@ public interface DinkPluginConfig extends Config {
         name = "Send Completed Tasks",
         description = "Send notifications upon completing a task",
         position = 204,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default boolean leaguesTaskCompletion() {
         return true;
@@ -1838,7 +1845,8 @@ public interface DinkPluginConfig extends Config {
         name = "Task Min Difficulty",
         description = "The minimum tier of a task for a notification to be sent",
         position = 205,
-        section = leaguesSection
+        section = leaguesSection,
+        hidden = true
     )
     default LeagueTaskDifficulty leaguesTaskMinTier() {
         return LeagueTaskDifficulty.EASY;

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -62,6 +62,11 @@ public class SettingsManager {
     private final Map<String, Collection<String>> keysBySection = new HashMap<>();
 
     /**
+     * The key names of config items that are hidden (and, thus, should not be exported).
+     */
+    private final Collection<String> hiddenConfigKeys = new HashSet<>();
+
+    /**
      * Set of our config keys that correspond to webhook URL lists.
      * <p>
      * These are used for special logic to merge the previous value with the new value during config imports.
@@ -101,6 +106,10 @@ public class SettingsManager {
         configManager.getConfigDescriptor(config).getItems().forEach(item -> {
             String key = item.key();
             configValueTypes.put(key, item.getType());
+
+            if (item.getItem().hidden()) {
+                hiddenConfigKeys.add(key);
+            }
 
             String section = item.getItem().section();
             if (StringUtils.isNotEmpty(section)) {
@@ -295,6 +304,7 @@ public class SettingsManager {
         Map<String, Object> configMap = configManager.getConfigurationKeys(prefix)
             .stream()
             .map(prop -> prop.substring(prefix.length()))
+            .filter(key -> !hiddenConfigKeys.contains(key))
             .filter(exportKey)
             .map(key -> Pair.of(key, configValueTypes.get(key)))
             .filter(pair -> pair.getValue() != null)

--- a/src/test/java/dinkplugin/notifiers/LeaguesNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LeaguesNotifierTest.java
@@ -14,6 +14,7 @@ import dinkplugin.notifiers.data.LeaguesTaskNotificationData;
 import net.runelite.api.Varbits;
 import net.runelite.api.WorldType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Disabled
 public class LeaguesNotifierTest extends MockedNotifierTest {
 
     @Bind


### PR DESCRIPTION
Retains the logic in the notifier class for easier reuse next leagues
