### PR TITLE
chore(deps): version bump and rename `gradle/gradle-build-action`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Execute Gradle build
         run: ./gradlew build

--- a/.github/workflows/gradle7.yml
+++ b/.github/workflows/gradle7.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: 11
 
       - name: Build plugin using hub gradle version
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4 # https://github.com/runelite/plugin-hub/blob/master/package/gradle/wrapper/gradle-wrapper.properties
           arguments: shadowJar -x test # tests are already executed by primary gradle task


### PR DESCRIPTION
bump to v3 and use their new alias because the old one probably won't get updates anymore