### PR TITLE
Release v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.8.3
+
 - Minor: Include Scurrius pet name in pet notifications. (#410)
 - Bugfix: Update death safe exceptions on config import from clipboard. (#406)
 - Dev: Disable leagues notifier. (#411)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.8.2"
+version = "1.8.3"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
version bumping now b/c without Scurries being handled, the pet notifs can incorrectly report dupe for the first instance of the pet.


Fixed an issue with `::dinkimport`-ing safe deaths, handle Scurries for pet notifs and disable the Leagues notifier.