### PR TITLE
Release v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.8.4
+
 - Minor: Fire loot notification for PK loot chests with sufficiently high total value. (#417)
 - Minor: Include region information in death notification metadata. (#420)
 - Minor: Allow customization of region IDs where deaths should be ignored. (#415)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.8.3"
+version = "1.8.4"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Handles the Graveyard Room in MTA as a safe death, allows the user to add death ignores based on regionID & adds a command for getting said regionID's, and changes how the minValue setting works in Loot notifications for PvP Loot Chests