### PR TITLE
chore: update plugin description for website

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Dink
 author=pajlads
 support=https://github.com/pajlads/DinkPlugin
-description=Discord-compatible webhook notifications for Loot, Death, Levels, CLog, KC, Diary, Quests, etc.
+description=Discord compatible webhook notifications for Loot, Death, Levels, CLog, KC, Diary, Quests, etc.
 tags=loot,logger,collection,pet,death,xp,level,notifications,discord,speedrun,diary,combat achievements,combat task,barbarian assault,high level gambles
 plugins=dinkplugin.DinkPlugin


### PR DESCRIPTION
changes `Discord-compatible` to `Discord compatible` for the plugin description used by the plugin hub [webpage](https://runelite.net/plugin-hub/) since the dash hinders searchability (i.e., searching `discord` will include dink but `discord ` does not) - this problem doesn't exist for the client-integrated search