### PR TITLE
fix: ensure config is initialized on plugin start

### DIFF
--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -126,6 +126,11 @@ public class SettingsManager {
             .addAll(keysBySection.getOrDefault(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", ""), Collections.emptySet()))
             .add("metadataWebhook") // MetaNotifier's configuration is in the Advanced section
             .build();
+
+        if (configManager.getConfiguration(CONFIG_GROUP, "discordWebhook") == null) {
+            // avoids edge case where runelite hasn't initialized our config but plugin is launched via shadow jar
+            configManager.setDefaultConfiguration(config, false);
+        }
     }
 
     void onCommand(CommandExecuted event) {


### PR DESCRIPTION
Discovered by @Felanbird upon switching to a fresh profile & launching our shadow jar

```
net.runelite.client.plugins.PluginInstantiationException: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "webhookUrl" is null
        at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:460)
        at net.runelite.client.plugins.PluginManager.lambda$startPlugins$2(PluginManager.java:241)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:308)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "webhookUrl" is null
        at dinkplugin.SettingsManager.hasModifiedConfig(SettingsManager.java:271)
        at dinkplugin.VersionManager.onStart(VersionManager.java:49)
        at dinkplugin.DinkPlugin.startUp(DinkPlugin.java:104)
        at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:438)
```
