### PR TITLE
fix: avoid NPE if webhook url hasn't been configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Major: Add item rarity to monster loot and collection notifications. (#425, #427)
 - Minor: Add wiki link for loot source in rich embeds. (#431)
-- Minor: Add chat message upon noteworthy plugin updates. (#429)
+- Minor: Add chat message upon noteworthy plugin updates. (#429, #436)
 - Minor: Allow loot notifications for rare items below the min value threshold. (#426)
 - Minor: Include relevant kill count in collection log notifications. (#424)
 - Minor: Obtain kill count from chat commands plugin for loot notifications. (#392)

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -268,7 +268,7 @@ public class SettingsManager {
     boolean hasModifiedConfig() {
         for (String webhookConfigKey : webhookConfigKeys) {
             String webhookUrl = configManager.getConfiguration(SettingsManager.CONFIG_GROUP, webhookConfigKey);
-            if (!webhookUrl.isEmpty()) {
+            if (webhookUrl != null && !webhookUrl.isEmpty()) {
                 return true;
             }
         }


### PR DESCRIPTION
Introduced in #429

Discovered by @Felanbird upon switching to a fresh profile & launching our shadow jar

```
net.runelite.client.plugins.PluginInstantiationException: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "webhookUrl" is null
        at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:460)
        at net.runelite.client.plugins.PluginManager.lambda$startPlugins$2(PluginManager.java:241)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:308)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "webhookUrl" is null
        at dinkplugin.SettingsManager.hasModifiedConfig(SettingsManager.java:271)
        at dinkplugin.VersionManager.onStart(VersionManager.java:49)
        at dinkplugin.DinkPlugin.startUp(DinkPlugin.java:104)
        at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:438)
```
