### PR TITLE
fix: exclude deny listed loot from rarity override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Major: Add notifier for chat messages that match custom patterns. (#391)
+- Bugfix: Exclude denylisted items from loot rarity override consideration. (#447)
 
 ## 1.9.1
 

--- a/src/main/java/dinkplugin/DinkPluginConfig.java
+++ b/src/main/java/dinkplugin/DinkPluginConfig.java
@@ -897,7 +897,7 @@ public interface DinkPluginConfig extends Config {
     @ConfigItem(
         keyName = "lootItemDenylist",
         name = "Item Denylist",
-        description = "Never fire notifications for these items, despite value settings.<br/>" +
+        description = "Never fire notifications for these items, despite value or rarity settings.<br/>" +
             "Place one item name per line (case-insensitive; asterisks are wildcards)",
         position = 37,
         section = lootSection

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -168,6 +168,27 @@ class LootNotifierTest extends MockedNotifierTest {
         verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
     }
 
+    @Test // https://github.com/pajlads/DinkPlugin/issues/446
+    void testIgnoreRarityDenyList() {
+        // update config mocks
+        when(config.minLootValue()).thenReturn(LARRAN_PRICE + 1);
+        when(config.lootRarityThreshold()).thenReturn(100);
+        notifier.onConfigChanged("lootItemDenylist", "Larran's key");
+
+        // prepare mocks
+        NPC npc = mock(NPC.class);
+        String name = "Ice spider";
+        when(npc.getName()).thenReturn(name);
+
+        // fire event
+        double rarity = 1.0 / 208;
+        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1, null)));
+        plugin.onNpcLootReceived(event);
+
+        // ensure no notification
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
     @Test
     void testNotifyAllowlist() {
         // prepare mocks


### PR DESCRIPTION
Closes #446
