### PR TITLE
fix: rename completed entries in collection notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Major: Add notifier for chat messages that match custom patterns. (#391)
+- Minor: `Completed Entries` field in Discord rich embed is now called `Completed`. (#448)
 - Bugfix: Exclude denylisted items from loot rarity override consideration. (#447)
 
 ## 1.9.1

--- a/src/main/java/dinkplugin/notifiers/data/CollectionNotificationData.java
+++ b/src/main/java/dinkplugin/notifiers/data/CollectionNotificationData.java
@@ -49,7 +49,7 @@ public class CollectionNotificationData extends NotificationData {
         List<Field> fields = new ArrayList<>(5);
         if (completedEntries != null && totalEntries != null) {
             fields.add(
-                new Field("Completed Entries", Field.formatProgress(completedEntries, totalEntries))
+                new Field("Completed", Field.formatProgress(completedEntries, totalEntries))
             );
         }
         if (dropperKillCount != null) {


### PR DESCRIPTION
This is the lazy way to better align the fields in collection notifications

There's still a little bit of an alignment jump, but it doesn't feel anywhere near as noticeable this way

<details>
<summary>before/after</summary>

![zilya_original](https://github.com/pajlads/DinkPlugin/assets/41973452/0682f417-8b3f-4502-a9c3-47addf177c9f)
![zilya](https://github.com/pajlads/DinkPlugin/assets/41973452/4a598187-3d42-43f9-9d82-ea8b37e5fee4)

</details>

also we could do this 
![image](https://github.com/pajlads/DinkPlugin/assets/41973452/1ae44e29-ea35-4f2d-8f49-63dfd9f7fe18)

