### PR TITLE
fix: check lunar chest count for kc notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Major: Add notifier for chat messages that match custom patterns. (#391)
 - Minor: `Completed Entries` field in Discord rich embed is now called `Completed`. (#448)
+- Bugfix: Allow Lunar Chest openings to trigger kill count notifier. (#449)
 - Bugfix: Exclude denylisted items from loot rarity override consideration. (#447)
 
 ## 1.9.1

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -43,7 +43,7 @@ public class KillCountNotifier extends BaseNotifier {
     public static final int KILL_COUNT_SPAM_FILTER = 4930;
     public static final String SPAM_WARNING = "Kill Count Notifier requires disabling the in-game setting: Filter out boss kill-count with spam-filter";
 
-    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>\\d+)\\b");
+    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>\\d+)\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>\\d+)\\b");
     private static final Pattern TIME_REGEX = Pattern.compile("(?:Duration|time|Subdued in):? (?<time>[\\d:]+(.\\d+)?)\\.?", Pattern.CASE_INSENSITIVE);
 
@@ -248,9 +248,13 @@ public class KillCountNotifier extends BaseNotifier {
 
     @Nullable
     private static String parsePrimaryBoss(String boss, String type) {
-        switch (type) {
+        switch (type.toLowerCase()) {
             case "chest":
-                return "Barrows".equalsIgnoreCase(boss) ? boss : null;
+                if ("Barrows".equalsIgnoreCase(boss))
+                    return boss;
+                if ("Lunar".equals(boss))
+                    return boss + " " + type;
+                return null;
 
             case "completion":
                 if ("Gauntlet".equalsIgnoreCase(boss))

--- a/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/KillCountNotifierTest.java
@@ -425,6 +425,29 @@ class KillCountNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testNotifyPerilousMoons() {
+        // update config mocks
+        when(config.killCountInterval()).thenReturn(10);
+
+        // fire events
+        String gameMessage = "Your Lunar Chest count is: 30.";
+        notifier.onGameMessage(gameMessage);
+        notifier.onTick();
+
+        // check notification
+        verify(messageHandler).createMessage(
+            PRIMARY_WEBHOOK_URL,
+            true,
+            NotificationBody.builder()
+                .text(buildTemplate("Lunar Chest", 30))
+                .extra(new BossNotificationData("Lunar Chest", 30, gameMessage, null, null))
+                .playerName(PLAYER_NAME)
+                .type(NotificationType.KILL_COUNT)
+                .build()
+        );
+    }
+
+    @Test
     void testNotifyBarbarianAssault() {
         // update mocks
         int count = 420;


### PR DESCRIPTION
Also populates `KillCountService` in case base chat commands plugin is not enabled

![image](https://github.com/pajlads/DinkPlugin/assets/8106344/20df3052-f875-4de0-8ac6-304a0cf23e05)
