### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.10.0
+
 - Major: Add notifier for chat messages that match custom patterns. (#391, #450)
 - Minor: Include Smol heredit pet name in pet notifications. (#458)
 - Minor: Prevent RuneLite from resetting empty config values for footer, ignored death regions, and chat patterns. (#454)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.9.1"
+version = "1.10.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.10.0 most notably adds a new notifier for chat messages that match user-specified patterns.
Also, the loot notifier now ignores the rarity of denylisted items for the rarity override setting.
In terms of Varlamore, the loot notifier has updated drop rate data, the pet notifier better supports Smol heredit, and the kill count notifier now tracks Lunar Chest openings.


https://github.com/pajlads/DinkPlugin/compare/v1.9.1...62ef660f2f881cc2b76cfde6270b1e64ce94488a
