### PR TITLE
fix: avoid NPE when single config item is reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Avoid benign NPE when config items are reset. (#464)
+
 ## 1.10.0
 
 - Major: Add notifier for chat messages that match custom patterns. (#391, #450)

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -186,7 +186,7 @@ public class SettingsManager {
             return;
         }
 
-        if (value.isEmpty() && ("embedFooterText".equals(key) || "embedFooterIcon".equals(key) || "deathIgnoredRegions".equals(key)) || ChatNotifier.PATTERNS_CONFIG_KEY.equals(key)) {
+        if (value != null && value.isEmpty() && ("embedFooterText".equals(key) || "embedFooterIcon".equals(key) || "deathIgnoredRegions".equals(key) || ChatNotifier.PATTERNS_CONFIG_KEY.equals(key))) {
             SwingUtilities.invokeLater(() -> {
                 if (StringUtils.isEmpty(configManager.getConfiguration(CONFIG_GROUP, key))) {
                     // non-empty string so runelite doesn't overwrite the value on next start; see https://github.com/pajlads/DinkPlugin/issues/453


### PR DESCRIPTION
Reported by @notheowner 

On runelite `ConfigManager#unsetConfiguration`, `ConfigChanged` is fired with null `newValue`  (rather than the default value that is the actual new config value) https://github.com/runelite/runelite/blob/ac52b2b01dc6df3414b8bad2d44884ea2dff29e0/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java#L940
