### PR TITLE
chore: remove deprecated ItemStack location usage

### DIFF
--- a/src/main/java/dinkplugin/util/ItemUtils.java
+++ b/src/main/java/dinkplugin/util/ItemUtils.java
@@ -60,7 +60,7 @@ public class ItemUtils {
     );
 
     private final BinaryOperator<Item> SUM_ITEM_QUANTITIES = (a, b) -> new Item(a.getId(), a.getQuantity() + b.getQuantity());
-    private final BinaryOperator<ItemStack> SUM_ITEM_STACK_QUANTITIES = (a, b) -> new ItemStack(a.getId(), a.getQuantity() + b.getQuantity(), a.getLocation());
+    private final BinaryOperator<ItemStack> SUM_ITEM_STACK_QUANTITIES = (a, b) -> new ItemStack(a.getId(), a.getQuantity() + b.getQuantity());
 
     public boolean isItemNeverKeptOnDeath(int itemId) {
         // https://oldschool.runescape.wiki/w/Items_Kept_on_Death#Items_that_are_never_kept

--- a/src/test/java/dinkplugin/UtilsTest.java
+++ b/src/test/java/dinkplugin/UtilsTest.java
@@ -41,26 +41,26 @@ class UtilsTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
                 Arguments.of(Collections.emptyList(), Collections.emptyList()),
-                Arguments.of(Collections.singletonList(new ItemStack(69, 1, null)), Collections.singletonList(new ItemStack(69, 1, null))),
+                Arguments.of(Collections.singletonList(new ItemStack(69, 1)), Collections.singletonList(new ItemStack(69, 1))),
                 Arguments.of(
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(70, 1, null)),
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(70, 1, null))
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(70, 1)),
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(70, 1))
                 ),
                 Arguments.of(
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(69, 1, null)),
-                    Collections.singletonList(new ItemStack(69, 2, null))
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(69, 1)),
+                    Collections.singletonList(new ItemStack(69, 2))
                 ),
                 Arguments.of(
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(69, 2, null)),
-                    Collections.singletonList(new ItemStack(69, 3, null))
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(69, 2)),
+                    Collections.singletonList(new ItemStack(69, 3))
                 ),
                 Arguments.of(
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(70, 2, null), new ItemStack(69, 3, null)),
-                    Arrays.asList(new ItemStack(69, 4, null), new ItemStack(70, 2, null))
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(70, 2), new ItemStack(69, 3)),
+                    Arrays.asList(new ItemStack(69, 4), new ItemStack(70, 2))
                 ),
                 Arguments.of(
-                    Arrays.asList(new ItemStack(69, 1, null), new ItemStack(69, 2, null), new ItemStack(69, 3, null)),
-                    Collections.singletonList(new ItemStack(69, 6, null))
+                    Arrays.asList(new ItemStack(69, 1), new ItemStack(69, 2), new ItemStack(69, 3)),
+                    Collections.singletonList(new ItemStack(69, 6))
                 )
             );
         }

--- a/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/CollectionNotifierTest.java
@@ -88,7 +88,7 @@ class CollectionNotifierTest extends MockedNotifierTest {
         when(npc.getName()).thenReturn(source);
         when(npc.getId()).thenReturn(NpcID.DAGANNOTH_SUPREME);
         when(configManager.getRSProfileConfiguration("killcount", source.toLowerCase(), int.class)).thenReturn(kc);
-        killCountService.onNpcKill(new NpcLootReceived(npc, List.of(new ItemStack(ItemID.SEERCULL, 1, null))));
+        killCountService.onNpcKill(new NpcLootReceived(npc, List.of(new ItemStack(ItemID.SEERCULL, 1))));
 
         // send fake message
         notifier.onChatMessage("New item added to your collection log: " + item);

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -91,7 +91,7 @@ class LootNotifierTest extends MockedNotifierTest {
                 ",\"first\":1667708688588,\"last\":1667708688588,\"drops\":[526,69,1603,1]}");
 
         // fire event
-        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)));
         plugin.onNpcLootReceived(event);
 
         // verify notification message
@@ -125,7 +125,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         double rarity = 1.0 / 208;
-        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1)));
         plugin.onNpcLootReceived(event);
 
         // verify notification message
@@ -149,6 +149,7 @@ class LootNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    @SuppressWarnings("unused")
     void testIgnoreNpcRarity() {
         // update config mocks
         when(config.minLootValue()).thenReturn(LARRAN_PRICE + 1);
@@ -161,7 +162,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         double rarity = 1.0 / 208;
-        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1)));
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
@@ -169,6 +170,7 @@ class LootNotifierTest extends MockedNotifierTest {
     }
 
     @Test // https://github.com/pajlads/DinkPlugin/issues/446
+    @SuppressWarnings("unused")
     void testIgnoreRarityDenyList() {
         // update config mocks
         when(config.minLootValue()).thenReturn(LARRAN_PRICE + 1);
@@ -182,7 +184,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         double rarity = 1.0 / 208;
-        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, List.of(new ItemStack(ItemID.LARRANS_KEY, 1)));
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
@@ -197,7 +199,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         notifier.onConfigChanged("lootItemAllowlist", "salmon\nraw trout\ntuna\npike");
-        PlayerLootReceived event = new PlayerLootReceived(player, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Collections.singletonList(new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // verify notification message
@@ -226,7 +228,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         notifier.onConfigChanged("lootItemAllowlist", "salmon\nraw trout\ntun*\npike");
-        PlayerLootReceived event = new PlayerLootReceived(player, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Collections.singletonList(new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // verify notification message
@@ -251,7 +253,7 @@ class LootNotifierTest extends MockedNotifierTest {
     void testIgnoreDenylist() {
         // fire event
         notifier.onConfigChanged("lootItemDenylist", "Ruby");
-        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // ensure no notification
@@ -262,7 +264,7 @@ class LootNotifierTest extends MockedNotifierTest {
     void testIgnoreDenylistWildcard() {
         // fire event
         notifier.onConfigChanged("lootItemDenylist", "Rub*");
-        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // ensure no notification
@@ -275,7 +277,7 @@ class LootNotifierTest extends MockedNotifierTest {
         String name = "The Whisperer";
 
         // fire event
-        LootReceived event = new LootReceived(name, 99, LootRecordType.NPC, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(name, 99, LootRecordType.NPC, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // verify notification message
@@ -306,7 +308,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(npc.getId()).thenReturn(NpcID.THE_WHISPERER);
 
         // fire event
-        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)));
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
@@ -320,7 +322,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(npc.getName()).thenReturn(LOOTED_NAME);
 
         // fire event
-        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)));
+        NpcLootReceived event = new NpcLootReceived(npc, Collections.singletonList(new ItemStack(ItemID.TUNA, 1)));
         plugin.onNpcLootReceived(event);
 
         // ensure no notification
@@ -330,7 +332,7 @@ class LootNotifierTest extends MockedNotifierTest {
     @Test
     void testNotifyPickpocket() {
         // fire event
-        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // verify notification message
@@ -354,7 +356,7 @@ class LootNotifierTest extends MockedNotifierTest {
     @Test
     void testIgnorePickpocket() {
         // fire event
-        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.TUNA, 1, null)), 1);
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.TUNA, 1)), 1);
         plugin.onLootReceived(event);
 
         // ensure no notification
@@ -368,7 +370,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         String source = "Clue Scroll (Medium)";
-        LootReceived event = new LootReceived(source, -1, LootRecordType.EVENT, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(source, -1, LootRecordType.EVENT, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // verify notification message
@@ -395,7 +397,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(config.lootIncludeClueScrolls()).thenReturn(false);
 
         // fire event
-        LootReceived event = new LootReceived("Clue Scroll (Medium)", -1, LootRecordType.EVENT, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived("Clue Scroll (Medium)", -1, LootRecordType.EVENT, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // ensure no notification
@@ -411,7 +413,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(player.getName()).thenReturn(LOOTED_NAME);
 
         // fire event
-        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1), new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // verify notification message
@@ -442,7 +444,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(player.getName()).thenReturn(LOOTED_NAME);
 
         // fire event
-        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1), new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // verify notification message
@@ -472,7 +474,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(player.getName()).thenReturn(LOOTED_NAME);
 
         // fire event
-        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1), new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // verify notification message
@@ -502,7 +504,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         String source = "Loot Chest";
-        List<ItemStack> items = List.of(new ItemStack(ItemID.OPAL, 1, null), new ItemStack(ItemID.TUNA, 2, null));
+        List<ItemStack> items = List.of(new ItemStack(ItemID.OPAL, 1), new ItemStack(ItemID.TUNA, 2));
         int totalValue = OPAL_PRICE + 2 * TUNA_PRICE;
         LootReceived event = new LootReceived(source, -1, LootRecordType.EVENT, items, 1);
         plugin.onLootReceived(event);
@@ -535,7 +537,7 @@ class LootNotifierTest extends MockedNotifierTest {
 
         // fire event
         String source = "Loot Chest";
-        List<ItemStack> items = List.of(new ItemStack(ItemID.OPAL, 1, null), new ItemStack(ItemID.TUNA, 1, null));
+        List<ItemStack> items = List.of(new ItemStack(ItemID.OPAL, 1), new ItemStack(ItemID.TUNA, 1));
         LootReceived event = new LootReceived(source, -1, LootRecordType.EVENT, items, 1);
         plugin.onLootReceived(event);
 
@@ -551,7 +553,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(config.includePlayerLoot()).thenReturn(false);
 
         // fire event
-        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1, null), new ItemStack(ItemID.TUNA, 1, null)));
+        PlayerLootReceived event = new PlayerLootReceived(player, Arrays.asList(new ItemStack(ItemID.RUBY, 1), new ItemStack(ItemID.TUNA, 1)));
         plugin.onPlayerLootReceived(event);
 
         // ensure no notification
@@ -567,9 +569,9 @@ class LootNotifierTest extends MockedNotifierTest {
             99,
             LootRecordType.EVENT,
             Arrays.asList(
-                new ItemStack(ItemID.RUBY, 1, null),
-                new ItemStack(ItemID.OPAL, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null)
+                new ItemStack(ItemID.RUBY, 1),
+                new ItemStack(ItemID.OPAL, 1),
+                new ItemStack(ItemID.TUNA, 1)
             ),
             3
         );
@@ -603,11 +605,11 @@ class LootNotifierTest extends MockedNotifierTest {
             99,
             LootRecordType.EVENT,
             Arrays.asList(
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null)
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1)
             ),
             5
         );
@@ -639,10 +641,10 @@ class LootNotifierTest extends MockedNotifierTest {
             99,
             LootRecordType.EVENT,
             Arrays.asList(
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null),
-                new ItemStack(ItemID.TUNA, 1, null)
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1),
+                new ItemStack(ItemID.TUNA, 1)
             ),
             4
         );
@@ -659,7 +661,7 @@ class LootNotifierTest extends MockedNotifierTest {
         int quantity = 24;
         String total = QuantityFormatter.quantityToStackSize(quantity * RUBY_PRICE);
         String source = "The Gauntlet";
-        List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity, null));
+        List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity));
 
         // fire events
         killCountService.onGameMessage(String.format("Your Gauntlet completion count is: %d.", kc));
@@ -691,7 +693,7 @@ class LootNotifierTest extends MockedNotifierTest {
         String total = QuantityFormatter.quantityToStackSize(quantity * RUBY_PRICE);
         String source = "The Gauntlet";
         String realSource = "Corrupted Gauntlet";
-        List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity, null));
+        List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity));
 
         // fire events
         killCountService.onGameMessage(String.format("Your Corrupted Gauntlet completion count is: %d.", kc));
@@ -721,7 +723,7 @@ class LootNotifierTest extends MockedNotifierTest {
         when(config.notifyLoot()).thenReturn(false);
 
         // fire event
-        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1, null)), 1);
+        LootReceived event = new LootReceived(LOOTED_NAME, 99, LootRecordType.PICKPOCKET, Collections.singletonList(new ItemStack(ItemID.RUBY, 1)), 1);
         plugin.onLootReceived(event);
 
         // ensure no notification


### PR DESCRIPTION
None of our notifiers actually use `ItemStack#getLocation`, but `ItemUtils` previously did because an alternative constructor didn't exist yet

https://github.com/runelite/runelite/commit/b0907b96bf7e47375611fbd8b0aff4f3577c6730
