### PR TITLE
Add Logout notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Send logout notifications to the Custom Metadata Handler in advanced settings. (#492)
 - Bugfix: Fire death notifications for Doom modifier in Fortis Colosseum. (#474)
 - Dev: Allow custom webhook handlers to use HTTP status code 307 and 308 to redirect requests. (#484)
 - Dev: Add message source to chat notification metadata. (#476)

--- a/docs/json-examples.md
+++ b/docs/json-examples.md
@@ -824,3 +824,12 @@ JSON for Login Notifications:
 
 `extra.pets` requires the base Chat Commands plugin to be enabled.  
 `collectionLog` data can be missing if the user does not have the Character Summary tab selected (since the client otherwise is not sent that data).
+
+JSON for Logout Notifications:
+
+```json5
+{
+  "type": "LOGOUT",
+  "content": "%USERNAME% logged out",
+}
+```

--- a/docs/json-examples.md
+++ b/docs/json-examples.md
@@ -830,6 +830,6 @@ JSON for Logout Notifications:
 ```json5
 {
   "type": "LOGOUT",
-  "content": "%USERNAME% logged out",
+  "content": "%USERNAME% logged out"
 }
 ```

--- a/src/main/java/dinkplugin/message/NotificationType.java
+++ b/src/main/java/dinkplugin/message/NotificationType.java
@@ -28,6 +28,7 @@ public enum NotificationType {
     LEAGUES_RELIC("Relic Chosen", "leaguesRelic.png", WIKI_IMG_BASE_URL + "Trailblazer_Reloaded_League_-_relics_icon.png"),
     LEAGUES_TASK("Task Completed", "leaguesTask.png", WIKI_IMG_BASE_URL + "Trailblazer_Reloaded_League_icon.png"),
     LOGIN("Player Login", "login.png", WIKI_IMG_BASE_URL + "Prop_sword.png"),
+    LOGOUT("Player Logout", "logout.png", WIKI_IMG_BASE_URL + "Prop_sword.png"),
     TRADE("Player Trade", "trade.png", WIKI_IMG_BASE_URL + "Inventory.png"),
     CHAT("Chat Notification", "chat.png", WIKI_IMG_BASE_URL + "Toggle_Chat_effects.png"),
     XP_MILESTONE("XP Milestone", "xpImage.png", WIKI_IMG_BASE_URL + "Lamp.png");

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -67,7 +67,7 @@ public class MetaNotifier extends BaseNotifier {
         // check if the oldState is any that can be considered "in game", and if the new state is "LOGIN_SCREEN"
         if ((oldState == GameState.LOGGED_IN || oldState == GameState.CONNECTION_LOST || oldState == GameState.LOADING)
             && newState == GameState.LOGIN_SCREEN && isEnabled()) {
-            NotifyLogout();
+            notifyLogout();
         }
     }
 
@@ -149,7 +149,7 @@ public class MetaNotifier extends BaseNotifier {
         );
     }
 
-    private void NotifyLogout() {
+    private void notifyLogout() {
         String playerName = Utils.getPlayerName(client);
         Template message = Template.builder()
             .replacementBoundary("%")

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -64,6 +64,11 @@ public class MetaNotifier extends BaseNotifier {
         if (oldState == GameState.LOGGING_IN && newState == GameState.LOGGED_IN) {
             loginTicks.set(INIT_TICKS);
         }
+        // check if the oldState is any that can be considered "in game", and if the new state is "LOGIN_SCREEN"
+        if ((oldState == GameState.LOGGED_IN || oldState == GameState.CONNECTION_LOST || oldState == GameState.LOADING)
+            && newState == GameState.LOGIN_SCREEN && isEnabled()) {
+            NotifyLogout();
+        }
     }
 
     public void onTick() {
@@ -139,6 +144,22 @@ public class MetaNotifier extends BaseNotifier {
             .type(NotificationType.LOGIN)
             .text(message)
             .extra(extra)
+            .playerName(playerName)
+            .build()
+        );
+    }
+
+    private void NotifyLogout() {
+        String playerName = Utils.getPlayerName(client);
+        Template message = Template.builder()
+            .replacementBoundary("%")
+            .template("%USERNAME% logged out")
+            .replacement("%USERNAME%", Replacements.ofText(playerName))
+            .build();
+
+        createMessage(false, NotificationBody.builder()
+            .type(NotificationType.LOGOUT)
+            .text(message)
             .playerName(playerName)
             .build()
         );

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -65,7 +65,7 @@ public class MetaNotifier extends BaseNotifier {
             loginTicks.set(INIT_TICKS);
         }
         // check if the oldState is any that can be considered "in game", and if the new state is "LOGIN_SCREEN"
-        if ((oldState == GameState.LOGGED_IN || oldState == GameState.CONNECTION_LOST || oldState == GameState.LOADING)
+        if ((oldState == GameState.LOGGED_IN || oldState == GameState.CONNECTION_LOST || oldState == GameState.HOPPING)
             && newState == GameState.LOGIN_SCREEN && isEnabled()) {
             notifyLogout();
         }

--- a/src/test/java/dinkplugin/notifiers/MetaNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MetaNotifierTest.java
@@ -187,7 +187,7 @@ class MetaNotifierTest extends MockedNotifierTest {
     }
 
     @Test
-    void TestLogoutNotify() {
+    void testLogoutNotify() {
         // Update config mock
         when(config.metadataWebhook()).thenReturn(url);
 

--- a/src/test/java/dinkplugin/notifiers/MetaNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MetaNotifierTest.java
@@ -185,4 +185,34 @@ class MetaNotifierTest extends MockedNotifierTest {
         );
         Assertions.assertEquals(expected, notifier.getPets());
     }
+
+    @Test
+    void TestLogoutNotify() {
+        // Update config mock
+        when(config.metadataWebhook()).thenReturn(url);
+
+        // fire event
+        notifier.onGameState(GameState.LOGGED_IN, GameState.LOGIN_SCREEN);
+        // verify notifier
+        verify(messageHandler).createMessage(
+            url,
+            false,
+            NotificationBody.builder()
+                .text(buildTemplate(PLAYER_NAME + " logged out"))
+                .type(NotificationType.LOGOUT)
+                .playerName(PLAYER_NAME)
+                .build()
+        );
+    }
+
+    @Test
+    void testLogoutDisabled() {
+        // update config mock
+        when(config.metadataWebhook()).thenReturn("");
+
+        // fire event
+        notifier.onGameState(GameState.LOGGED_IN, GameState.LOGIN_SCREEN);
+        // ensure no notification
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
 }


### PR DESCRIPTION
This pull request adds a logout message to the metadata notifier. This message will be sent when the gamestate changes from a gamestate that is considered to be in-game, to the "LOGIN_SCREEN" gamestate.

This notifier message intentionally includes no extra data. The only thing worth considering would've been the world, but that is expected to be included by default after PR #490, and knowing which world the player logs out from didn't seem all that useful anyway.

Closes #491