### PR TITLE
Release v1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.10.2
+
 - Minor: Allow RuneLite notifier messages to trigger the Dink chat notifier. (#493)
 - Minor: Include player region and world for non-Discord custom webhook handlers via metadata for all notifiers. (#490)
 - Minor: Allow client commands to trigger the chat notifier. (#489)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.10.1"
+version = "1.10.2"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.10.2 most notably expands message sources for the chat notifier, augments notification metadata, and fixes some edge cases for the loot and death notifiers.