### PR TITLE
 chore(ci): avoid deprecated gradle arguments parameter

### DIFF
--- a/.github/workflows/gradle7.yml
+++ b/.github/workflows/gradle7.yml
@@ -13,8 +13,10 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - name: Build plugin using hub gradle version
+      - name: Setup hub gradle version
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4 # https://github.com/runelite/plugin-hub/blob/master/package/gradle/wrapper/gradle-wrapper.properties
-          arguments: shadowJar -x test # tests are already executed by primary gradle task
+
+      - name: Build plugin using hub gradle version
+        run: ./gradlew shadowJar -x test # tests are already executed by primary gradle task

--- a/.github/workflows/gradle7.yml
+++ b/.github/workflows/gradle7.yml
@@ -19,4 +19,4 @@ jobs:
           gradle-version: 7.4 # https://github.com/runelite/plugin-hub/blob/master/package/gradle/wrapper/gradle-wrapper.properties
 
       - name: Build plugin using hub gradle version
-        run: ./gradlew shadowJar -x test # tests are already executed by primary gradle task
+        run: ./gradlew shadowJar --exclude-task test # tests are already executed by primary gradle task


### PR DESCRIPTION
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated
