### PR TITLE
chore: resolve lombok warning

### DIFF
--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -133,7 +133,7 @@ public class GrandExchangeNotifier extends BaseNotifier {
                 return false;
 
             // check whether the completion has already been observed
-            if (getSavedOffer(slot).filter(saved -> saved.equals(offer)).isPresent())
+            if (getSavedOffer(slot).filter(saved -> saved.equalsOffer(offer)).isPresent())
                 return false;
         }
 
@@ -170,7 +170,7 @@ public class GrandExchangeNotifier extends BaseNotifier {
                 if (spacing < 0)
                     return false; // negative => no in-progress notifications allowed
 
-                if (getSavedOffer(slot).filter(saved -> saved.equals(offer)).isPresent())
+                if (getSavedOffer(slot).filter(saved -> saved.equalsOffer(offer)).isPresent())
                     return false; // ignore since quantity already observed (relevant when trade limit is binding)
 
                 // convert minutes to seconds, but treat 0 minutes as 2 seconds to workaround duplicate RL events

--- a/src/main/java/dinkplugin/util/SerializedOffer.java
+++ b/src/main/java/dinkplugin/util/SerializedOffer.java
@@ -17,7 +17,7 @@ public class SerializedOffer {
     private int price;
     private int spent;
 
-    public boolean equals(@NotNull GrandExchangeOffer o) {
+    public boolean equalsOffer(@NotNull GrandExchangeOffer o) {
         return state == o.getState() && id == o.getItemId() && quantity == o.getTotalQuantity()
             && price == o.getPrice() && spent == o.getSpent();
     }


### PR DESCRIPTION
avoids clash of `SerializedOffer#equals(Object)` and `SerializedOffer#equals(GrandExchangeOffer)`, which was preventing lombok from generating `SerializedOffer#hashCode`
