### PR TITLE
fix: ensure embed count is within discord limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Fire death and loot notifications when 10 or more item icons were embedded. (#509)
+
 ## 1.10.3
 
 - Minor: Add advanced setting to keep config synchronized with a remote URL. (#488)

--- a/src/main/java/dinkplugin/message/DiscordMessageHandler.java
+++ b/src/main/java/dinkplugin/message/DiscordMessageHandler.java
@@ -383,7 +383,7 @@ public class DiscordMessageHandler {
             ? body.getThumbnailUrl()
             : type.getThumbnail();
 
-        List<Embed> embeds = new ArrayList<>(body.getEmbeds() != null ? body.getEmbeds() : Collections.emptyList());
+        List<Embed> embeds = new ArrayList<>(body.getEmbeds() != null ? body.getEmbeds().subList(0, Math.min(body.getEmbeds().size(), Embed.MAX_EMBEDS - 1)) : Collections.emptyList());
         embeds.add(0,
             Embed.builder()
                 .author(author)

--- a/src/main/java/dinkplugin/message/Embed.java
+++ b/src/main/java/dinkplugin/message/Embed.java
@@ -22,6 +22,7 @@ public class Embed {
     public static final int MAX_IMAGE_SIZE = 8_000_000; // 8MB
     public static final int MAX_DESCRIPTION_LENGTH = 4096;
     public static final int MAX_FOOTER_LENGTH = 2048;
+    public static final int MAX_EMBEDS = 10;
 
     /**
      * Filled in with the title of {@link NotificationBody}.


### PR DESCRIPTION
Ensure discord notifications are fired for the following scenarios:

* safe deaths with `deathEmbedKeptItems` enabled (default: disabled), `deathIgnoreSafe` disabled (default: enabled), and 10+ items in inventory/equipment
* loot drop of 10+ items with `lootIcons` enabled (default: disabled)
