### PR TITLE
fix(level): avoid early initialization of skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Include rarity and luck for pet notifications. (#433)
+- Bugfix: Avoid level notification upon login. (#514)
 - Dev: Add raid party members to loot notification metadata. (#478)
 
 ## 1.10.4

--- a/src/main/java/dinkplugin/notifiers/LevelNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LevelNotifier.java
@@ -17,6 +17,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.StatChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.util.QuantityFormatter;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -36,7 +37,7 @@ import static net.runelite.api.Experience.MAX_REAL_LEVEL;
 @Singleton
 public class LevelNotifier extends BaseNotifier {
     public static final int LEVEL_FOR_MAX_XP = Experience.MAX_VIRT_LEVEL + 1; // 127
-    private static final int INIT_GAME_TICKS = 16; // ~10s
+    static final @VisibleForTesting int INIT_GAME_TICKS = 16; // ~10s
     private static final int SKILL_COUNT = Skill.values().length;
     private static final String COMBAT_NAME = "Combat";
     private static final Set<String> COMBAT_COMPONENTS;

--- a/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LevelNotifierTest.java
@@ -68,7 +68,7 @@ class LevelNotifierTest extends MockedNotifierTest {
         plugin.onStatChanged(new StatChanged(Skill.HUNTER, 300, 4, 4));
         plugin.onStatChanged(new StatChanged(Skill.SLAYER, 9_800_000, 96, 96));
         plugin.onStatChanged(new StatChanged(Skill.FARMING, Experience.MAX_SKILL_XP, 99, 99));
-        notifier.onTick();
+        IntStream.rangeClosed(0, LevelNotifier.INIT_GAME_TICKS + 1).forEach(i -> notifier.onTick());
     }
 
     @Test


### PR DESCRIPTION
previously `INIT_GAME_TICKS` was effectively ignored since receiving skill data on first tick would set `shouldInit` to true

actually fixes #262

also simplifies some counter logic (atomic was overkill)
