### PR TITLE
fix: clear particular notifier state when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Include rarity and luck for pet notifications. (#433)
+- Bugfix: Avoid outdated notification data if disabling and enabling notifiers over time. (#515)
 - Dev: Add raid party members to loot notification metadata. (#478)
 
 ## 1.10.4


### PR DESCRIPTION
avoids outdated notification data if players are disabling and enabling notifiers (while plugin remains enabled)

for example: disable level notifier, gain a level, later enable level notifier, get single xp drop for same skill => previously dink would trigger a level notif (tho level up occurred much earlier)
