### PR TITLE
fix: parse killcount notifs over 999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Add rarity of Nid for pet notiications. (#536)
+- Bugfix: Report KC for killcount notifications correctly after Jagex change. (#539)
 
 ## 1.10.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Minor: Add rarity of Nid for pet notiications. (#536)
-- Bugfix: Report KC for killcount notifications correctly after Jagex change. (#539)
+- Bugfix: Report KC for killcount notifications over 999 correctly after Jagex change. (#539)
 
 ## 1.10.7
 

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -44,7 +44,7 @@ public class KillCountNotifier extends BaseNotifier {
     public static final int KILL_COUNT_SPAM_FILTER = 4930;
     public static final String SPAM_WARNING = "Kill Count Notifier requires disabling the in-game setting: Filter out boss kill-count with spam-filter";
 
-    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>\\d+)\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>[\\d,]+)\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>\\d+)\\b");
     private static final Pattern TIME_REGEX = Pattern.compile("(?:Duration|time|Subdued in):? (?<time>[\\d:]+(.\\d+)?)\\.?", Pattern.CASE_INSENSITIVE);
 

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -45,7 +45,7 @@ public class KillCountNotifier extends BaseNotifier {
     public static final String SPAM_WARNING = "Kill Count Notifier requires disabling the in-game setting: Filter out boss kill-count with spam-filter";
 
     private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>[\\d,]+)\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>\\d+)\\b");
+    private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>[\\d,]+)\\b");
     private static final Pattern TIME_REGEX = Pattern.compile("(?:Duration|time|Subdued in):? (?<time>[\\d:]+(.\\d+)?)\\.?", Pattern.CASE_INSENSITIVE);
 
     private static final String BA_BOSS_NAME = "Penance Queen";

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -240,7 +240,7 @@ public class KillCountNotifier extends BaseNotifier {
     private static Optional<Pair<String, Integer>> result(String boss, String count) {
         // safely transform (String, String) => (String, Int)
         try {
-            return Optional.ofNullable(boss).map(k -> Pair.of(boss, Integer.parseInt(count)));
+            return Optional.ofNullable(boss).map(k -> Pair.of(boss, Integer.parseInt(count.replace(",", ""))));
         } catch (NumberFormatException e) {
             log.debug("Failed to parse kill count [{}] for boss [{}]", count, boss);
             return Optional.empty();

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -138,14 +138,14 @@ public class KillCountService {
 
         // guardians of the rift count (for pet tracking)
         if (message.startsWith(RIFT_PREFIX)) {
-            int riftCount = Integer.parseInt(message.substring(RIFT_PREFIX.length(), message.length() - 1));
+            int riftCount = Integer.parseInt(message.substring(RIFT_PREFIX.length(), message.length() - 1).replace(",", ""));
             killCounts.put("Guardians of the Rift", riftCount);
             return;
         }
 
         // herbiboar count (for pet tracking)
         if (message.startsWith(HERBIBOAR_PREFIX)) {
-            int harvestCount = Integer.parseInt(message.substring(HERBIBOAR_PREFIX.length(), message.length() - 1));
+            int harvestCount = Integer.parseInt(message.substring(HERBIBOAR_PREFIX.length(), message.length() - 1).replace(",", ""));
             killCounts.put("Herbiboar", harvestCount);
             return;
         }


### PR DESCRIPTION
I didn't actually test if the current implementation can handle a `<value>` with a comma in it, but here's the base change.