### PR TITLE
chore: avoid unconfigurable image embeds when rich embeds are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Don't include boss images when rich embed is disabled. (#541)
+- Minor: Don't include boss/icon images when rich embed is disabled. (#541)
 
 ## 1.10.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Don't include boss images when rich embed is disabled. (#541)
+
 ## 1.10.8
 
 - Minor: Add rarity of Nid for pet notiications. (#536)

--- a/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/GrandExchangeNotifier.java
@@ -95,10 +95,10 @@ public class GrandExchangeNotifier extends BaseNotifier {
         Long tax = type == OfferType.SELL ? calculateTax(item.getPriceEach(), item.getQuantity(), item.getId()) : null;
 
         List<Embed> embeds;
-        if (config.grandExchangeSendImage()) {
+        if (config.grandExchangeSendImage() || !config.discordRichEmbeds()) {
             embeds = Collections.emptyList();
         } else {
-            embeds = ItemUtils.buildEmbeds(new int[]{offer.getItemId()});
+            embeds = ItemUtils.buildEmbeds(new int[] { offer.getItemId() });
         }
 
         String playerName = Utils.getPlayerName(client);

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -154,7 +154,7 @@ public class KillCountNotifier extends BaseNotifier {
 
         // Add embed if not screenshotting
         boolean screenshot = config.killCountSendImage();
-        if (!screenshot) {
+        if (!screenshot && config.discordRichEmbeds()) {
             if (ba) {
                 body.embeds(Collections.singletonList(Embed.ofImage(ItemUtils.getNpcImageUrl(NpcID.PENANCE_QUEEN))));
             } else {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bff81ade-66e1-43ef-8cae-269d582e5abd)
