### PR TITLE
feat: use thumbnail corresponding to clue difficulty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Minor: Use embed thumbnail that corresponds to clue scroll difficulty. (#546)
+
 ## 1.10.9
 
 - Minor: Don't include boss/icon images when rich embed is disabled. (#541)

--- a/src/main/java/dinkplugin/notifiers/ClueNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ClueNotifier.java
@@ -122,12 +122,14 @@ public class ClueNotifier extends BaseNotifier {
                 .replacement("%TOTAL_VALUE%", Replacements.ofText(QuantityFormatter.quantityToStackSize(totalPrice.get())))
                 .replacement("%LOOT%", lootMessage.build())
                 .build();
+            String icon = String.format("https://oldschool.runescape.wiki/images/Clue_scroll_(%s).png", clueType.toLowerCase());
             createMessage(screenshot,
                 NotificationBody.builder()
                     .text(notifyMessage)
                     .extra(new ClueNotificationData(clueType, clueCount, itemStacks))
                     .type(NotificationType.CLUE)
                     .embeds(embeds)
+                    .thumbnailUrl(icon)
                     .build()
             );
         }


### PR DESCRIPTION
Closes #544

![image](https://github.com/user-attachments/assets/1aee21ea-bdb1-48a3-9dcb-91109e604cbd)
