### PR TITLE
chore: disable scheduled resource updates on forks

### DIFF
--- a/.github/workflows/update-resources.yml
+++ b/.github/workflows/update-resources.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-resources:
+    if: ${{ github.repository_owner == 'pajlads' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
no need for forks to get PRs when wiki updates