### PR TITLE
feat: Include isPersonalBest & time in Kill Count JSON Example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
-- Minor: Updates the Kill Count JSON Example to show isPersonalBest and time. (#601)
 - Minor: Enable the leagues notifier again. (#597)
 - Bugfix: Identify all CoX members from raiding party widget. (#600)
+- Dev: Clarify json example for kill counter notifier to include `time` and `isPersonalBest`. (#601)
 
 ## 1.10.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Updates the Kill Count JSON Example to show isPersonalBest and time. (#601)
 - Minor: Enable the leagues notifier again. (#597)
 - Bugfix: Identify all CoX members from raiding party widget. (#600)
 

--- a/docs/json-examples.md
+++ b/docs/json-examples.md
@@ -326,16 +326,18 @@ JSON for Kill Count Notifications:
 {
   "content": "%USERNAME% has defeated %BOSS% with a completion count of %COUNT%",
   "extra": {
-    "isPersonalBest": true,
     "boss": "Chambers of Xeric",
     "count": 69,
     "gameMessage": "Your completed Chambers of Xeric count is: 69.",
-    "time": "PT4634S",
+    "time": "PT46M34S",
+    "isPersonalBest": true,
     "party": ["%USERNAME%", "another RSN", "yet another RSN"]
   },
   "type": "KILL_COUNT"
 }
 ```
+
+When an associated duration is not found, `extra.time` is reported as zero seconds and `extra.isPersonalBest` is not populated.
 
 Note: when `boss` is `Penance Queen`, `count` refers to the high level gamble count, rather than kill count.
 

--- a/docs/json-examples.md
+++ b/docs/json-examples.md
@@ -326,9 +326,11 @@ JSON for Kill Count Notifications:
 {
   "content": "%USERNAME% has defeated %BOSS% with a completion count of %COUNT%",
   "extra": {
+    "isPersonalBest": true,
     "boss": "Chambers of Xeric",
     "count": 69,
     "gameMessage": "Your completed Chambers of Xeric count is: 69.",
+    "time": "PT4634S",
     "party": ["%USERNAME%", "another RSN", "yet another RSN"]
   },
   "type": "KILL_COUNT"


### PR DESCRIPTION
I noticed when reviewing the `json-examples.md` for the Kill Count payload structure it was missing `isPersonalBest` and `time`. This adds those two fields. Mainly, this will help show people what `ISO-8601` duration looks like.