### PR TITLE
feat: Add Herbiboar to Kill Count Notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Allows Kill Count Notifier to track Herbiboar KC. (#602);
 - Minor: Enable the leagues notifier again. (#597)
 - Bugfix: Identify all CoX members from raiding party widget. (#600)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Minor: Allows Kill Count Notifier to track Herbiboar KC. (#602);
+- Minor: Add herbiboar support to kill count notifier. (#602)
 - Minor: Enable the leagues notifier again. (#597)
 - Bugfix: Identify all CoX members from raiding party widget. (#600)
 - Dev: Clarify json example for kill counter notifier to include `time` and `isPersonalBest`. (#601)

--- a/docs/json-examples.md
+++ b/docs/json-examples.md
@@ -337,7 +337,7 @@ JSON for Kill Count Notifications:
 }
 ```
 
-When an associated duration is not found, `extra.time` is reported as zero seconds and `extra.isPersonalBest` is not populated.
+When an associated duration is not found, `extra.time` and `extra.isPersonalBest` are not populated.
 
 Note: when `boss` is `Penance Queen`, `count` refers to the high level gamble count, rather than kill count.
 

--- a/src/main/java/dinkplugin/VersionManager.java
+++ b/src/main/java/dinkplugin/VersionManager.java
@@ -131,5 +131,6 @@ public class VersionManager {
         register("1.10.2", "Chat notifier can read commands and RL notifications");
         register("1.10.5", "Pet notifications now report rarity and luck");
         register("1.10.12", "Rarity is now reported for notable pickpocket loot");
+        register("1.10.14", "Kill count notifier now triggers for Herbiboar");
     }
 }

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -38,7 +38,7 @@ public class KillCountNotifier extends BaseNotifier {
     public static final int KILL_COUNT_SPAM_FILTER = 4930;
     public static final String SPAM_WARNING = "Kill Count Notifier requires disabling the in-game setting: Filter out boss kill-count with spam-filter";
 
-    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion)\\s?count is: (?<value>[\\d,]+)\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PRIMARY_REGEX = Pattern.compile("Your (?<key>.+)\\s(?<type>kill|chest|completion|harvest)\\s?count is: (?<value>[\\d,]+)\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern SECONDARY_REGEX = Pattern.compile("Your (?:completed|subdued) (?<key>.+) count is: (?<value>[\\d,]+)\\b");
     private static final Pattern TIME_REGEX = Pattern.compile("(?:Duration|time|Subdued in):? (?<time>[\\d:]+(.\\d+)?)\\.?", Pattern.CASE_INSENSITIVE);
 
@@ -244,6 +244,9 @@ public class KillCountNotifier extends BaseNotifier {
                 if (KillCountService.CG_NAME.equalsIgnoreCase(boss))
                     return KillCountService.CG_BOSS;
                 return null;
+            case "harvest":
+                if (KillCountService.HERBIBOAR.equalsIgnoreCase(boss))
+                return KillCountService.HERBIBOAR;
 
             case "kill":
                 return boss;

--- a/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/KillCountNotifier.java
@@ -244,9 +244,10 @@ public class KillCountNotifier extends BaseNotifier {
                 if (KillCountService.CG_NAME.equalsIgnoreCase(boss))
                     return KillCountService.CG_BOSS;
                 return null;
+
             case "harvest":
                 if (KillCountService.HERBIBOAR.equalsIgnoreCase(boss))
-                return KillCountService.HERBIBOAR;
+                    return KillCountService.HERBIBOAR;
 
             case "kill":
                 return boss;

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -41,7 +41,6 @@ public class KillCountService {
     public static final String GAUNTLET_NAME = "Gauntlet", GAUNTLET_BOSS = "Crystalline Hunllef";
     public static final String CG_NAME = "Corrupted Gauntlet", CG_BOSS = "Corrupted Hunllef";
     public static final String HERBIBOAR = "Herbiboar";
-
     public static final String TOA = "Tombs of Amascut";
     public static final String TOB = "Theatre of Blood";
     public static final String COX = "Chambers of Xeric";

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -40,6 +40,8 @@ public class KillCountService {
 
     public static final String GAUNTLET_NAME = "Gauntlet", GAUNTLET_BOSS = "Crystalline Hunllef";
     public static final String CG_NAME = "Corrupted Gauntlet", CG_BOSS = "Corrupted Hunllef";
+    public static final String HERBIBOAR = "Herbiboar";
+
     public static final String TOA = "Tombs of Amascut";
     public static final String TOB = "Theatre of Blood";
     public static final String COX = "Chambers of Xeric";

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -147,7 +147,7 @@ public class KillCountService {
         // herbiboar count (for pet tracking)
         if (message.startsWith(HERBIBOAR_PREFIX)) {
             int harvestCount = Integer.parseInt(message.substring(HERBIBOAR_PREFIX.length(), message.length() - 1).replace(",", ""));
-            killCounts.put("Herbiboar", harvestCount);
+            killCounts.put(HERBIBOAR, harvestCount);
             return;
         }
 

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -129,7 +129,7 @@ class MatchersTest {
 
                 // skilling special case
                 Arguments.of("Your subdued Wintertodt count is: 359", Pair.of("Wintertodt", 359)),
-                Arguments.of("Your herbiboar harvest count is: 2332", Pair.of("Herbiboar", 2332)),
+                Arguments.of("Your herbiboar harvest count is: 2332.", Pair.of("Herbiboar", 2332)),
 
                 // minigame special cases
                 Arguments.of("Your Barrows chest count is: 268", Pair.of("Barrows", 268)),

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -129,7 +129,7 @@ class MatchersTest {
 
                 // skilling special case
                 Arguments.of("Your subdued Wintertodt count is: 359", Pair.of("Wintertodt", 359)),
-                Arguments.of("Your herbiboar harvest count is: 2332", Pair.of("Wintertodt", 2332)),
+                Arguments.of("Your herbiboar harvest count is: 2332", Pair.of("Herbiboar", 2332)),
 
                 // minigame special cases
                 Arguments.of("Your Barrows chest count is: 268", Pair.of("Barrows", 268)),
@@ -169,7 +169,7 @@ class MatchersTest {
 
     private static class GambleProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
                 Arguments.of("Magic seed! High level gamble count: 1.", new GambleNotifier.ParsedData("Magic seed", 1, null, 1)),
                 Arguments.of("Limpwurt root (x 37)! High level gamble count: 65.", new GambleNotifier.ParsedData("Limpwurt root", 37, null, 65)),

--- a/src/test/java/dinkplugin/notifiers/MatchersTest.java
+++ b/src/test/java/dinkplugin/notifiers/MatchersTest.java
@@ -110,8 +110,7 @@ class MatchersTest {
     @ParameterizedTest(name = "Kill count message should not trigger on: {0}")
     @ValueSource(
         strings = {
-            "Forsen: forsen",
-            "Your heriboar harvest count is: 69."
+            "Forsen: forsen"
         }
     )
     void killCountRegexDoesNotMatch(String message) {
@@ -130,6 +129,7 @@ class MatchersTest {
 
                 // skilling special case
                 Arguments.of("Your subdued Wintertodt count is: 359", Pair.of("Wintertodt", 359)),
+                Arguments.of("Your herbiboar harvest count is: 2332", Pair.of("Wintertodt", 2332)),
 
                 // minigame special cases
                 Arguments.of("Your Barrows chest count is: 268", Pair.of("Barrows", 268)),


### PR DESCRIPTION
Allows Heribobar kill counts to send kill count notifications. Wintertodt and Tempoross are acceptable so we should include Herbiboar to keep the "skilling" NPCs consistent. We should also consider adding Hunter Rumour completions.

![image](https://github.com/user-attachments/assets/b8379019-890a-44b7-bc70-554fa86e15d3)