### PR TITLE
fix: manually update tasks for area unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Minor: Manually confirm the points for each relic tier in Leagues 5. (#607)
+- Bugfix: Report correct tasks until next area for Leagues 5. (#613)
 
 ## 1.10.15
 

--- a/src/main/java/dinkplugin/notifiers/LeaguesNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LeaguesNotifier.java
@@ -347,7 +347,7 @@ public class LeaguesNotifier extends BaseNotifier {
 
     static {
         AREA_BY_TASKS = Collections.unmodifiableNavigableMap(
-            new TreeMap<>(Map.of(0, 0, 60, 1, 140, 2, 300, 3))
+            new TreeMap<>(Map.of(0, 0, 90, 1, 200, 2, 400, 3))
         );
 
         NavigableMap<Integer, String> thresholds = new TreeMap<>();

--- a/src/main/java/dinkplugin/notifiers/LeaguesNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LeaguesNotifier.java
@@ -55,6 +55,9 @@ public class LeaguesNotifier extends BaseNotifier {
     @VisibleForTesting
     static final @Varbit int FIVE_AREAS = 10666, FOUR_AREAS = 10665, THREE_AREAS = 10664, TWO_AREAS = 10663; // TODO: are these still correct?
 
+    @VisibleForTesting
+    static final int FIRST_AREA_TASKS = 90, SECOND_AREA_TASKS = 200, THIRD_AREA_TASKS = 400;
+
     /**
      * @see <a href="https://github.com/Joshua-F/cs2-scripts/blob/fa31b06ec5a9f6636bf9b9d5cbffbb71df022d06/scripts/[proc%2Cscript2451].cs2#L3-L6">CS2 Reference</a>
      * @see <a href="https://abextm.github.io/cache2/#/viewer/enum/2670">Enum Reference</a>
@@ -347,7 +350,7 @@ public class LeaguesNotifier extends BaseNotifier {
 
     static {
         AREA_BY_TASKS = Collections.unmodifiableNavigableMap(
-            new TreeMap<>(Map.of(0, 0, 90, 1, 200, 2, 400, 3))
+            new TreeMap<>(Map.of(0, 0, FIRST_AREA_TASKS, 1, SECOND_AREA_TASKS, 2, THIRD_AREA_TASKS, 3))
         );
 
         NavigableMap<Integer, String> thresholds = new TreeMap<>();

--- a/src/test/java/dinkplugin/notifiers/LeaguesNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LeaguesNotifierTest.java
@@ -20,7 +20,7 @@ import org.mockito.InjectMocks;
 
 import java.util.EnumSet;
 
-import static dinkplugin.notifiers.LeaguesNotifier.CURRENT_LEAGUE_NAME;
+import static dinkplugin.notifiers.LeaguesNotifier.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.never;
@@ -67,7 +67,7 @@ public class LeaguesNotifierTest extends MockedNotifierTest {
 
         // verify notification
         String area = "Kandarin";
-        int tasksUntilNextArea = 300 - tasksCompleted;
+        int tasksUntilNextArea = THIRD_AREA_TASKS - tasksCompleted;
         verifyCreateMessage(
             PRIMARY_WEBHOOK_URL,
             false,
@@ -100,7 +100,7 @@ public class LeaguesNotifierTest extends MockedNotifierTest {
 
         // verify notification
         String area = "Karamja";
-        int tasksUntilNextArea = 60 - tasksCompleted;
+        int tasksUntilNextArea = FIRST_AREA_TASKS - tasksCompleted;
         verifyCreateMessage(
             PRIMARY_WEBHOOK_URL,
             false,
@@ -165,7 +165,7 @@ public class LeaguesNotifierTest extends MockedNotifierTest {
         // verify notification
         String taskName = "The Frozen Door";
         LeagueTaskDifficulty difficulty = LeagueTaskDifficulty.HARD;
-        int tasksUntilNextArea = 140 - tasksCompleted;
+        int tasksUntilNextArea = SECOND_AREA_TASKS - tasksCompleted;
         int pointsUntilNextRelic = LeagueRelicTier.THREE.getDefaultPoints() - totalPoints;
         int pointsUntilNextTrophy = 2_500 - totalPoints;
         verifyCreateMessage(
@@ -200,7 +200,7 @@ public class LeaguesNotifierTest extends MockedNotifierTest {
         // verify notification
         String taskName = "The Frozen Door";
         LeagueTaskDifficulty difficulty = LeagueTaskDifficulty.HARD;
-        int tasksUntilNextArea = 140 - tasksCompleted;
+        int tasksUntilNextArea = SECOND_AREA_TASKS - tasksCompleted;
         int pointsUntilNextRelic = LeagueRelicTier.FIVE.getDefaultPoints() - totalPoints;
         int pointsUntilNextTrophy = 5_000 - totalPoints;
         String trophy = "Bronze";
@@ -238,7 +238,7 @@ public class LeaguesNotifierTest extends MockedNotifierTest {
         // verify notification
         String taskName = "Equip Amy's Saw";
         LeagueTaskDifficulty difficulty = LeagueTaskDifficulty.MEDIUM;
-        int tasksUntilNextArea = 300 - tasksCompleted;
+        int tasksUntilNextArea = THIRD_AREA_TASKS - tasksCompleted;
         int pointsUntilNextRelic = LeagueRelicTier.SIX.getDefaultPoints() - totalPoints;
         int pointsUntilNextTrophy = 10_000 - totalPoints;
         String trophy = "Iron";


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Raging_Echoes_League/Areas

dink is reporting wrong # tasks until next area unlock bc we aren't pulling these thresholds from cache