### PR TITLE
ci(snapshot): allow some caching unrelated to dep versions

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -17,4 +17,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build using latest runelite snapshot version
-        run: ./gradlew --no-build-cache -Puse.snapshot clean build -x test
+        run: ./gradlew --refresh-dependencies -Puse.snapshot clean build -x test


### PR DESCRIPTION
no need to disable the full build cache to grab the latest snapshot jar