### PR TITLE
feat: handle royal titans loot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Fire loot notifications for new Royal Titans bosses. (#650)
 - Minor: Include Bran pet name in pet notifications. (#649)
 - Minor: Add `%SENDER%` template variable for chat notifier. (#644)
 - Bugfix: Ignore misconfigured loot value-rarity intersection setting if rarity threshold is not configured. (#647)

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -52,9 +52,9 @@ public class KillCountService {
 
     public static final Set<Integer> SPECIAL_LOOT_NPC_IDS = Set.of(
         NpcID.THE_WHISPERER, NpcID.THE_WHISPERER_12205, NpcID.THE_WHISPERER_12206, NpcID.THE_WHISPERER_12207,
-        NpcID.ARAXXOR, NpcID.ARAXXOR_13669
+        NpcID.ARAXXOR, NpcID.ARAXXOR_13669, 14148, 14149
     );
-    public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor");
+    public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor", "Branda the Fire Queen", "Eldric the Ice King");
 
     @Inject
     private ConfigManager configManager;


### PR DESCRIPTION
need loot tracker event for royal titans rather than NpcLootReceived https://github.com/runelite/runelite/commit/f76f4dc1f97f91681a36b28a147a2a32585456f6

npc id's are currently hardcoded until runelite pushes the next version so we can use the NpcID constant
