### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.11.0
+
 - Major: Allow external plugins to request Dink webhook notifications. (#666)
 
 ## 1.10.23

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.10.23"
+version = "1.11.0"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.11.0 allows other plugins to trigger webhook notifications via `PluginMessage`