### PR TITLE
fix(external): harden url input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Harden input validation for urls provided to the external plugin notifier. (#672)
+
 ## 1.11.1
 
 - Dev: Require users to opt-in to the external plugin notifier. (#670)

--- a/src/main/java/dinkplugin/domain/ExternalNotificationRequest.java
+++ b/src/main/java/dinkplugin/domain/ExternalNotificationRequest.java
@@ -3,7 +3,6 @@ package dinkplugin.domain;
 import dinkplugin.message.Field;
 import dinkplugin.message.templating.impl.SimpleReplacement;
 import lombok.Data;
-import okhttp3.HttpUrl;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -24,11 +23,11 @@ public class ExternalNotificationRequest {
     private @Nullable List<Field> fields;
     private @Nullable Map<String, SimpleReplacement> replacements;
     private @Nullable Map<String, Object> metadata;
-    private @Nullable List<HttpUrl> urls;
+    private @Nullable List<String> urls;
 
     public String getUrls(Supplier<String> defaultValue) {
         return urls != null
-            ? urls.stream().filter(Objects::nonNull).map(HttpUrl::toString).collect(Collectors.joining("\n"))
+            ? urls.stream().filter(Objects::nonNull).collect(Collectors.joining("\n"))
             : defaultValue.get();
     }
 

--- a/src/main/java/dinkplugin/notifiers/ExternalPluginNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/ExternalPluginNotifier.java
@@ -48,6 +48,12 @@ public class ExternalPluginNotifier extends BaseNotifier {
             return;
         }
 
+        // ensure input urls are specified correctly
+        if (!isUrlInputValid(data.get("urls"))) {
+            log.warn("Skipping externally-requested dink due to invalid 'urls' format from {}", data.get("sourcePlugin"));
+            return;
+        }
+
         // parse request
         ExternalNotificationRequest input;
         try {
@@ -103,6 +109,20 @@ public class ExternalPluginNotifier extends BaseNotifier {
 
         var urls = input.getUrls(this::getWebhookUrl);
         createMessage(urls, image, body);
+    }
+
+    private static boolean isUrlInputValid(Object urls) {
+        if (urls == null) {
+            return true; // use urls specified in dink's config
+        }
+        if (!(urls instanceof Iterable)) {
+            return false; // we try to convert to list in ExternalNotificationRequest
+        }
+        for (Object url : (Iterable<?>) urls) {
+            if (!(url instanceof HttpUrl))
+                return false; // received non-HttpUrl; input should be rejected
+        }
+        return true; // all elements are HttpUrl instances; proceed as normal
     }
 
 }

--- a/src/test/java/dinkplugin/notifiers/ExternalPluginNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/ExternalPluginNotifierTest.java
@@ -209,6 +209,19 @@ public class ExternalPluginNotifierTest extends MockedNotifierTest {
     }
 
     @Test
+    void testIgnoreBadUrls() {
+        // prepare payload
+        var data = samplePayload(null);
+        data.put("urls", List.of("https://example.com/"));
+
+        // fire event
+        plugin.onPluginMessage(new PluginMessage("dink", "notify", data));
+
+        // ensure no notification
+        verify(messageHandler, never()).createMessage(any(), anyBoolean(), any());
+    }
+
+    @Test
     void testDisabled() {
         // update config mocks
         when(config.notifyExternal()).thenReturn(false);


### PR DESCRIPTION
ensures external plugins can't evade the code scanner by providing `List<String>` instead of `List<HttpUrl>`
