### PR TITLE
filter out plugin-sourced chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: Ignore fake game messages submitted by other external plugins. (#691)
 - Dev: Fix link to `dinkHandler.js` example. (#684)
 
 ## 1.11.3

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -24,7 +24,6 @@ import dinkplugin.notifiers.SpeedrunNotifier;
 import dinkplugin.notifiers.TradeNotifier;
 import dinkplugin.util.KillCountService;
 import dinkplugin.util.Utils;
-import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.GameState;

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -24,6 +24,7 @@ import dinkplugin.notifiers.SpeedrunNotifier;
 import dinkplugin.notifiers.TradeNotifier;
 import dinkplugin.util.KillCountService;
 import dinkplugin.util.Utils;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.GameState;
@@ -240,6 +241,11 @@ public class DinkPlugin extends Plugin {
         chatNotifier.onMessage(message.getType(), source, chatMessage);
         switch (message.getType()) {
             case GAMEMESSAGE:
+                if ("runelite".equals(source)) {
+                    // filter out plugin-sourced chat messages
+                    return;
+                }
+
                 collectionNotifier.onChatMessage(chatMessage);
                 petNotifier.onChatMessage(chatMessage);
                 killCountService.onGameMessage(chatMessage);


### PR DESCRIPTION
this is intended to be combined with lalochazia/missed-clues#2 to prevent erroneous pet events

maybe it should affect `chatNotifier.onMessage` too? not sure enough on that one