### PR TITLE
feat: Add Delimiter to DeathNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Apply cleaner formatting to value lost reported in death notifications. (#719)
 - Minor: Allow configuration of account types that should not trigger notifications. (#701)
 
 ## 1.11.5

--- a/src/main/java/dinkplugin/notifiers/DeathNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/DeathNotifier.java
@@ -32,6 +32,7 @@ import net.runelite.api.events.ScriptPreFired;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.NPCManager;
+import net.runelite.client.util.QuantityFormatter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -273,7 +274,7 @@ public class DeathNotifier extends BaseNotifier {
             .template(template)
             .replacementBoundary("%")
             .replacement("%USERNAME%", Replacements.ofText(Utils.getPlayerName(client)))
-            .replacement("%VALUELOST%", Replacements.ofText(String.valueOf(losePrice)));
+            .replacement("%VALUELOST%", Replacements.ofText(QuantityFormatter.quantityToStackSize(losePrice)));
         if (pvp) {
             builder.replacement("%PKER%", Replacements.ofText(killer));
         } else if (npc) {

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -289,7 +289,7 @@ class DeathNotifierTest extends MockedNotifierTest {
         when(client.isPrayerActive(Prayer.PROTECT_ITEM)).thenReturn(true);
         Item[] items = {
             new Item(ItemID.RUBY, 1),
-            new Item(ItemID.TUNA, 1),
+            new Item(ItemID.TUNA, 99999),
             new Item(ItemID.COAL, 1),
             new Item(ItemID.SHARK, 1),
             new Item(ItemID.OPAL, 1),
@@ -315,8 +315,8 @@ class DeathNotifierTest extends MockedNotifierTest {
             PRIMARY_WEBHOOK_URL,
             false,
             NotificationBody.builder()
-                .text(buildTemplate(String.format("%s has died, losing %d gp", PLAYER_NAME, TUNA_PRICE)))
-                .extra(new DeathNotificationData(TUNA_PRICE, false, null, null, null, kept, lost, Region.of(client)))
+                .text(buildTemplate(String.format("%s has died, losing %s gp", PLAYER_NAME, "10M")))
+                .extra(new DeathNotificationData(9999900L, false, null, null, null, kept, lost, Region.of(client)))
                 .type(NotificationType.DEATH)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/DeathNotifierTest.java
@@ -316,7 +316,7 @@ class DeathNotifierTest extends MockedNotifierTest {
             false,
             NotificationBody.builder()
                 .text(buildTemplate(String.format("%s has died, losing %s gp", PLAYER_NAME, "10M")))
-                .extra(new DeathNotificationData(9999900L, false, null, null, null, kept, lost, Region.of(client)))
+                .extra(new DeathNotificationData(99999 * TUNA_PRICE, false, null, null, null, kept, lost, Region.of(client)))
                 .type(NotificationType.DEATH)
                 .build()
         );


### PR DESCRIPTION
Updates the `%VALUELOST%` to be a formatted value. Closes #708 

![image](https://github.com/user-attachments/assets/6dfcf69e-c275-4393-a03f-cafb72687703)
