### PR TITLE
Release v1.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.11.7
+
 - Dev: Migrate to GameVal constants defined by Jagex. (#705)
 
 ## 1.11.6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 }
 
 group = "dinkplugin"
-version = "1.11.6"
+version = "1.11.7"
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"


### PR DESCRIPTION
Dink v1.11.7 migrates to gameval constants

https://github.com/pajlads/DinkPlugin/compare/v1.11.6...chore/release-1.11.7
