### PR TITLE
chore(pet): add Yami drop rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add drop rate of Yami pet for luck calculations. (#736)
 - Minor: Parse slayer kill log for more accurate kill count reporting. (#718)
 - Bugfix: Fire loot notifications for Yama. (#734)
 

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -550,7 +550,7 @@ public class PetNotifier extends BaseNotifier {
             entry("Vet'ion jr.", new MultiKcSource("Vet'ion", 1.0 / 1_500, "Calvar'ion", 1.0 / 2_800)),
             entry("Vorki", new KcSource("Vorkath", 1.0 / 3_000)),
             entry("Wisp", new KcSource("The Whisperer", 1.0 / 2_000)),
-            entry("Yami", new KcSource("Yama", null)), // unknown drop rate
+            entry("Yami", new KcSource("Yama", 1.0 / 2_500)),
             entry("Youngllef", new MultiKcSource("Gauntlet", 1.0 / 2_000, "Corrupted Gauntlet", 1.0 / 800))
         );
     }


### PR DESCRIPTION
cook made a reddit post the other day about the post-nerf droprates, and yami is still 1/2500 as of today