### PR TITLE
fix: fire gauntlet loot notifications after rl change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Minor: Add loot notification for Pharaoh's sceptre. (#742)
 - Minor: Update formula for Grand Exchange tax after Jagex change. (#743)
+- Bugfix: Fire loot notifications for (Corrupted) Gauntlet after loot tracker change. (#746)
 - Dev: Notify metadata handler upon rolling a TOA purple chest. (#740)
 
 ## 1.11.9

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -155,7 +155,7 @@ public class LootNotifier extends BaseNotifier {
         } else if (lootReceived.getType() == LootRecordType.NPC && KillCountService.SPECIAL_LOOT_NPC_NAMES.contains(lootReceived.getName())) {
             // Special case: upstream fires LootReceived for certain NPCs, but not NpcLootReceived
             String source = killCountService.getStandardizedSource(lootReceived);
-            var type = KillCountService.GAUNTLET_NAME.equals(source) || KillCountService.CG_NAME.equals(source) ? LootRecordType.EVENT : lootReceived.getType();
+            var type = KillCountService.THE_GAUNTLET.equals(source) || KillCountService.CG_NAME.equals(source) ? LootRecordType.EVENT : lootReceived.getType();
             this.handleNotify(lootReceived.getItems(), source, type, null);
         }
     }

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -155,7 +155,8 @@ public class LootNotifier extends BaseNotifier {
         } else if (lootReceived.getType() == LootRecordType.NPC && KillCountService.SPECIAL_LOOT_NPC_NAMES.contains(lootReceived.getName())) {
             // Special case: upstream fires LootReceived for certain NPCs, but not NpcLootReceived
             String source = killCountService.getStandardizedSource(lootReceived);
-            this.handleNotify(lootReceived.getItems(), source, lootReceived.getType(), null);
+            var type = KillCountService.GAUNTLET_NAME.equals(source) || KillCountService.CG_NAME.equals(source) ? LootRecordType.EVENT : lootReceived.getType();
+            this.handleNotify(lootReceived.getItems(), source, type, null);
         }
     }
 

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -154,7 +154,8 @@ public class LootNotifier extends BaseNotifier {
             this.handleNotify(lootReceived.getItems(), source, lootReceived.getType(), null);
         } else if (lootReceived.getType() == LootRecordType.NPC && KillCountService.SPECIAL_LOOT_NPC_NAMES.contains(lootReceived.getName())) {
             // Special case: upstream fires LootReceived for certain NPCs, but not NpcLootReceived
-            this.handleNotify(lootReceived.getItems(), lootReceived.getName(), lootReceived.getType(), null);
+            String source = killCountService.getStandardizedSource(lootReceived);
+            this.handleNotify(lootReceived.getItems(), source, lootReceived.getType(), null);
         }
     }
 

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -63,7 +63,7 @@ public class KillCountService {
         NpcID.ARAXXOR, NpcID.ARAXXOR_DEAD, NpcID.RT_FIRE_QUEEN_INACTIVE, NpcID.RT_ICE_KING_INACTIVE
     );
     public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor",
-        "Branda the Fire Queen", "Eldric the Ice King", "Corrupted Hunllef");
+        "Branda the Fire Queen", "Eldric the Ice King", "Crystalline Hunllef", "Corrupted Hunllef");
 
     @Inject
     private ConfigManager configManager;

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -62,7 +62,8 @@ public class KillCountService {
         NpcID.WHISPERER, NpcID.WHISPERER_MELEE, NpcID.WHISPERER_QUEST, NpcID.WHISPERER_MELEE_QUEST,
         NpcID.ARAXXOR, NpcID.ARAXXOR_DEAD, NpcID.RT_FIRE_QUEEN_INACTIVE, NpcID.RT_ICE_KING_INACTIVE
     );
-    public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor", "Branda the Fire Queen", "Eldric the Ice King");
+    public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor",
+        "Branda the Fire Queen", "Eldric the Ice King", "Corrupted Hunllef");
 
     @Inject
     private ConfigManager configManager;

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -209,8 +209,10 @@ public class KillCountService {
     }
 
     public String getStandardizedSource(LootReceived event) {
-        if (isCorruptedGauntlet(event)) {
-            return KillCountService.CG_NAME;
+        if (GAUNTLET_BOSS.equals(event.getName())) {
+            return GAUNTLET_NAME;
+        } else if (CG_BOSS.equals(event.getName())) {
+            return CG_NAME;
         } else if (lastDrop != null && shouldUseChatName(event)) {
             return lastDrop.getSource(); // distinguish entry/expert/challenge modes
         }
@@ -222,17 +224,6 @@ public class KillCountService {
         String lastSource = lastDrop.getSource();
         Predicate<String> coincides = source -> source.equals(event.getName()) && lastSource.startsWith(source);
         return coincides.test(TOA) || coincides.test(TOB) || coincides.test(COX);
-    }
-
-    /**
-     * @param event a loot received event that was just fired
-     * @return whether the event represents corrupted gauntlet
-     * @apiNote Useful to distinguish normal vs. corrupted gauntlet since the base loot tracker plugin does not,
-     * which was <a href="https://github.com/pajlads/DinkPlugin/issues/469">reported</a> to our issue tracker.
-     */
-    private boolean isCorruptedGauntlet(LootReceived event) {
-        return event.getType() == LootRecordType.EVENT && lastDrop != null && "The Gauntlet".equals(event.getName())
-            && (CG_NAME.equals(lastDrop.getSource()) || CG_BOSS.equals(lastDrop.getSource()));
     }
 
     @Nullable
@@ -398,7 +389,8 @@ public class KillCountService {
      * @return lowercase boss name that {@link ChatCommandsPlugin} uses during serialization
      */
     private static String cleanBossName(String boss) {
-        if ("The Gauntlet".equalsIgnoreCase(boss)) return "gauntlet";
+        if ("The Gauntlet".equalsIgnoreCase(boss) || GAUNTLET_BOSS.equals(boss)) return "gauntlet";
+        if (CG_BOSS.equals(boss)) return "corrupted gauntlet";
         if ("The Leviathan".equalsIgnoreCase(boss)) return "leviathan";
         if ("The Whisperer".equalsIgnoreCase(boss)) return "whisperer";
         if ("The Hueycoatl".equalsIgnoreCase(boss)) return "hueycoatl";

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -46,7 +46,7 @@ import java.util.function.Predicate;
 @Singleton
 public class KillCountService {
 
-    public static final String GAUNTLET_NAME = "Gauntlet", GAUNTLET_BOSS = "Crystalline Hunllef";
+    public static final String GAUNTLET_NAME = "Gauntlet", GAUNTLET_BOSS = "Crystalline Hunllef", THE_GAUNTLET = "The Gauntlet";
     public static final String CG_NAME = "Corrupted Gauntlet", CG_BOSS = "Corrupted Hunllef";
     public static final String HERBIBOAR = "Herbiboar";
     public static final String TOA = "Tombs of Amascut";
@@ -210,7 +210,7 @@ public class KillCountService {
 
     public String getStandardizedSource(LootReceived event) {
         if (GAUNTLET_BOSS.equals(event.getName())) {
-            return GAUNTLET_NAME;
+            return THE_GAUNTLET;
         } else if (CG_BOSS.equals(event.getName())) {
             return CG_NAME;
         } else if (lastDrop != null && shouldUseChatName(event)) {
@@ -390,7 +390,7 @@ public class KillCountService {
      * @return lowercase boss name that {@link ChatCommandsPlugin} uses during serialization
      */
     private static String cleanBossName(String boss) {
-        if ("The Gauntlet".equalsIgnoreCase(boss) || GAUNTLET_BOSS.equals(boss)) return "gauntlet";
+        if (THE_GAUNTLET.equalsIgnoreCase(boss) || GAUNTLET_BOSS.equals(boss)) return "gauntlet";
         if (CG_BOSS.equals(boss)) return "corrupted gauntlet";
         if ("The Leviathan".equalsIgnoreCase(boss)) return "leviathan";
         if ("The Whisperer".equalsIgnoreCase(boss)) return "whisperer";
@@ -411,7 +411,7 @@ public class KillCountService {
             default:
                 // exceptions where boss name in chat message differs from npc name
                 if ("Whisperer".equals(sourceName)) return "The Whisperer";
-                if ("The Gauntlet".equals(sourceName)) return GAUNTLET_BOSS;
+                if (THE_GAUNTLET.equals(sourceName)) return GAUNTLET_BOSS;
                 if (CG_NAME.equals(sourceName)) return CG_BOSS;
 
                 return sourceName;

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -63,7 +63,7 @@ public class KillCountService {
         NpcID.ARAXXOR, NpcID.ARAXXOR_DEAD, NpcID.RT_FIRE_QUEEN_INACTIVE, NpcID.RT_ICE_KING_INACTIVE
     );
     public static final Set<String> SPECIAL_LOOT_NPC_NAMES = Set.of("The Whisperer", "Araxxor",
-        "Branda the Fire Queen", "Eldric the Ice King", "Crystalline Hunllef", "Corrupted Hunllef");
+        "Branda the Fire Queen", "Eldric the Ice King", GAUNTLET_BOSS, CG_BOSS);
 
     @Inject
     private ConfigManager configManager;

--- a/src/main/java/dinkplugin/util/KillCountService.java
+++ b/src/main/java/dinkplugin/util/KillCountService.java
@@ -221,6 +221,7 @@ public class KillCountService {
 
     private boolean shouldUseChatName(LootReceived event) {
         assert lastDrop != null;
+        if (event.getType() != LootRecordType.EVENT) return false;
         String lastSource = lastDrop.getSource();
         Predicate<String> coincides = source -> source.equals(event.getName()) && lastSource.startsWith(source);
         return coincides.test(TOA) || coincides.test(TOB) || coincides.test(COX);

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -741,7 +741,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{source}}", Replacements.ofWiki(realSource))
                         .build()
                 )
-                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), realSource, LootRecordType.NPC, kc, null, null, null))
+                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), realSource, LootRecordType.EVENT, kc, null, null, null))
                 .type(NotificationType.LOOT)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -689,12 +689,14 @@ class LootNotifierTest extends MockedNotifierTest {
         int kc = 123;
         int quantity = 24;
         String total = QuantityFormatter.quantityToStackSize(quantity * RUBY_PRICE);
-        String source = "The Gauntlet";
+        String source = "Crystalline Hunllef";
+        String realSource = "The Gauntlet";
         List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity));
+        mockNpcs(new NPC[0]);
 
         // fire events
         killCountService.onGameMessage(String.format("Your Gauntlet completion count is: %d.", kc));
-        plugin.onLootReceived(new LootReceived(source, -1, LootRecordType.EVENT, items, 1));
+        plugin.onLootReceived(new LootReceived(source, 674, LootRecordType.NPC, items, 1));
 
         // verify notification message
         verifyCreateMessage(
@@ -705,10 +707,10 @@ class LootNotifierTest extends MockedNotifierTest {
                     Template.builder()
                         .template(String.format("%s has looted: %d x {{ruby}} (%s) from {{source}} for %s gp", PLAYER_NAME, quantity, total, total))
                         .replacement("{{ruby}}", Replacements.ofWiki("Ruby"))
-                        .replacement("{{source}}", Replacements.ofWiki(source))
+                        .replacement("{{source}}", Replacements.ofWiki(realSource))
                         .build()
                 )
-                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), source, LootRecordType.EVENT, kc, null, null, null))
+                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), realSource, LootRecordType.EVENT, kc, null, null, null))
                 .type(NotificationType.LOOT)
                 .build()
         );

--- a/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/LootNotifierTest.java
@@ -720,13 +720,14 @@ class LootNotifierTest extends MockedNotifierTest {
         int kc = 123;
         int quantity = 24;
         String total = QuantityFormatter.quantityToStackSize(quantity * RUBY_PRICE);
-        String source = "The Gauntlet";
+        String source = "Corrupted Hunllef";
         String realSource = "Corrupted Gauntlet";
         List<ItemStack> items = List.of(new ItemStack(ItemID.RUBY, quantity));
+        mockNpcs(new NPC[0]);
 
         // fire events
         killCountService.onGameMessage(String.format("Your Corrupted Gauntlet completion count is: %d.", kc));
-        plugin.onLootReceived(new LootReceived(source, -1, LootRecordType.EVENT, items, 1));
+        plugin.onLootReceived(new LootReceived(source, 894, LootRecordType.NPC, items, 1));
 
         // verify notification message
         verifyCreateMessage(
@@ -740,7 +741,7 @@ class LootNotifierTest extends MockedNotifierTest {
                         .replacement("{{source}}", Replacements.ofWiki(realSource))
                         .build()
                 )
-                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), realSource, LootRecordType.EVENT, kc, null, null, null))
+                .extra(new LootNotificationData(List.of(new AnnotatedItemStack(ItemID.RUBY, quantity, RUBY_PRICE, "Ruby", EnumSet.of(LootCriteria.VALUE))), realSource, LootRecordType.NPC, kc, null, null, null))
                 .type(NotificationType.LOOT)
                 .build()
         );


### PR DESCRIPTION
First contribution ever, not sure if this is remotely close to the solution or not.

[Issue #744](https://github.com/pajlads/DinkPlugin/issues/744) is something I've noticed myself, looks like the loot tracking for **The Gauntlet** has changed to **Corrupted Hunllef**, I'm not sure if this results it in becoming a special loot NPC or not.

Not sure what other implications this brings if it is in fact this issue.