### PR TITLE
fix(metanotifier): Make onVarbit check for isEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Avoid sending TOA unique message to primary webhook when metadata webhook is absent. (#755)
+
 ## 1.11.10
 
 - Minor: Add loot notification for Pharaoh's sceptre. (#742)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Bugfix: Avoid sending TOA unique message to primary webhook when metadata webhook is absent. (#755)
+- Bugfix: Avoid sending TOA unique message to primary webhook when metadata webhook is absent. (#756)
 
 ## 1.11.10
 

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -83,7 +83,7 @@ public class MetaNotifier extends BaseNotifier {
     }
 
     public void onVarbit(VarbitChanged event) {
-        if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1) {
+        if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1 && isEnabled()) {
             clientThread.invokeAtTickEnd(this::notifyPurpleAmascut);
         }
     }


### PR DESCRIPTION
Add isEnabled check to onVarbit as it was firing without metadata handler being filled out

Fixes https://github.com/pajlads/DinkPlugin/issues/755