### PR TITLE
fix: delay ge notifications on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: Delay grand exchange notifications while welcome screen is visible. (#763)
 - Bugfix: Allow commas and semicolons in chat notifier message patterns. (#761)
 - Bugfix: Allow external plugins to trigger notifications off of the client thread again. (#759)
 - Bugfix: Avoid sending TOA unique message to primary webhook when metadata webhook is absent. (#756)


### PR DESCRIPTION
avoids calling `AccountTypeTracker` before it is ready (and prevents screenshot before user has clicked play button)