### PR TITLE
fix: use jagex loot event for hallowed sepulchre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Fire loot notifications for Hallowed Sepulchre after loot tracker change. (#789)
+
 ## 1.11.12
 
 - Minor: Include Dom pet name in pet notifications. (#783)

--- a/src/main/java/dinkplugin/DinkPlugin.java
+++ b/src/main/java/dinkplugin/DinkPlugin.java
@@ -328,7 +328,8 @@ public class DinkPlugin extends Plugin {
     public void onServerNpcLoot(ServerNpcLoot event) {
         // temporarily only use new event when needed
         int npcId = event.getComposition().getId();
-        if (npcId != NpcID.YAMA && npcId != NpcID.HESPORI) {
+        var name = event.getComposition().getName();
+        if (npcId != NpcID.YAMA && npcId != NpcID.HESPORI && !name.startsWith("Hallowed Sepulchre")) {
             return;
         }
 


### PR DESCRIPTION
Closes #787  (not tested)