### PR TITLE
test: mock initialize config.customPlayerBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Dev: Mock initialize `config.customPlayerBadge` in tests. (#884)
+
 ## 1.11.24
 
 - Bugfix: Fix missing Soup pet notifications due to faulty rarity logic. (#876)

--- a/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
+++ b/src/test/java/dinkplugin/notifiers/MockedNotifierTest.java
@@ -161,6 +161,7 @@ abstract class MockedNotifierTest extends MockedTestBase {
         when(config.nameFilterMode()).thenReturn(FilterMode.DENY);
         when(config.embedColor()).thenReturn(Utils.PINK);
         when(config.deniedAccountTypes()).thenReturn(EnumSet.noneOf(AccountType.class));
+        when(config.customPlayerBadge()).thenReturn("");
 
         accountTracker.init();
         worldTracker.init();


### PR DESCRIPTION
When `TEST_WEBHOOK_URL` is set to a real URL, we would get to the point
where the player badge was being built for real, and we ran into an NPE
when reading `config.customPlayerBadge()`
