### PR TITLE
chore: Add dink-filter project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Dink powers a variety of third-party projects including:
 
 - [Watchdog](https://github.com/adamk33n3r/runelite-watchdog): RuneLite hub plugin that can trigger custom Dink notifications
 - [Leppunen's Dink Handler](https://git.ivr.fi/Leppunen/runelite-dink-api): JS-based (Fastify) webhook handler that forwards Dink notifications to a Twitch chatbot
+- [Zneix's Dink filter](https://github.com/zneix/dink-filter): Golang-based application that applies custom logic before forwarding Dink notifications
 - [Swap's Webhook Handler](https://github.com/jdanthdavis/custom-dink-webhook): Cloudflare Worker that applies custom logic before forwarding Dink notifications
 - [Danbot](https://github.com/DanbisDev/Danbot-Webserver): Python-based (Flask) Discord bot that parses Dink notifications
 - [stabiliserver](https://github.com/Fuzznip/stabiliserver): Python-based (FastAPI) Discord bot that parses Dink notifications


### PR DESCRIPTION
I've created an application ( https://github.com/zneix/dink-filter ) that can have destination-specific rules and will forward dink requests/notifications only if they satisfy those specified rules.

The rules are ergonomic via configuration file in the application.
I have plans to expand it and add a small dashboard to which users could login and specify their own rulesets & destinations, though I'm not sure if that's a good idea and whether I want this/if there is interest, but for now it's only really useful for the application hoster.
