### PR TITLE
fix: stop duplicate toa notifcations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-## 1.13.3
-
 - Bugfix: Stop duplicate TOA unique notifcations (#914)
 
 ## 1.13.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Bugfix: Stop duplicate TOA unique notifcations (#914)
+- Bugfix: Prevent duplicate TOA unique notifications for the metadata handler. (#924)
 
 ## 1.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.13.3
+
+- Bugfix: Stop duplicate TOA unique notifcations (#914)
+
 ## 1.13.2
 
 - Bugfix: Fire loot notifications from sailing NPCs. (#921)

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -16,6 +16,7 @@ import dinkplugin.util.ConfigUtil;
 import dinkplugin.util.ItemUtils;
 import dinkplugin.util.SerializedPet;
 import dinkplugin.util.Utils;
+import dinkplugin.util.WorldUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
@@ -23,7 +24,6 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Skill;
 import net.runelite.api.annotations.Varbit;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
@@ -51,8 +51,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MetaNotifier extends BaseNotifier {
     static final @VisibleForTesting String RL_CHAT_CMD_PLUGIN_NAME = ChatCommandsPlugin.class.getSimpleName().toLowerCase();
     static final @VisibleForTesting int INIT_TICKS = 10; // 6 seconds after login
-
-    private static final int TOA_REWARD_CHAMBER_REGIONID = 14672;
 
     private static final int[] TOA_CHEST_VARBS;
 
@@ -166,8 +164,8 @@ public class MetaNotifier extends BaseNotifier {
         }
 
         // Only fire notification if local player region is equal to the TOA reward chamber.
-        int playerRegion = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
-        if ( playerRegion != TOA_REWARD_CHAMBER_REGIONID ) {
+        int playerRegion = WorldUtils.getLocation(client).getRegionID();
+        if (playerRegion != WorldUtils.TOA_REWARD_CHAMBER_REGIONID) {
             return;
         }
 
@@ -244,7 +242,7 @@ public class MetaNotifier extends BaseNotifier {
         // Fire notification
         String playerName = Utils.getPlayerName(client);
         cachedPlayerName = playerName;
-        
+
         Template message = Template.builder()
             .replacementBoundary("%")
             .template("%USERNAME% logged into World %WORLD%")
@@ -286,6 +284,8 @@ public class MetaNotifier extends BaseNotifier {
             .template("%USERNAME% logged out")
             .replacement("%USERNAME%", Replacements.ofText(playerName))
             .build();
+        cachedPlayerName = null;
+
 
         createMessage(false, NotificationBody.builder()
             .type(NotificationType.LOGOUT)

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -165,7 +165,7 @@ public class MetaNotifier extends BaseNotifier {
 
         // Only fire notification if local player region is equal to the TOA reward chamber.
         int playerRegion = WorldUtils.getLocation(client).getRegionID();
-        if (playerRegion != WorldUtils.TOA_REWARD_CHAMBER_REGIONID) {
+        if (playerRegion != WorldUtils.TOA_REWARD_CHAMBER_REGION) {
             return;
         }
 

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -25,6 +25,7 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Skill;
 import net.runelite.api.annotations.Varbit;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
@@ -59,8 +60,6 @@ public class MetaNotifier extends BaseNotifier {
 
     private final AtomicInteger loginTicks = new AtomicInteger(-1);
 
-    private final DinkPlugin plugin;
-
     @Inject
     private ClientThread clientThread;
 
@@ -72,12 +71,6 @@ public class MetaNotifier extends BaseNotifier {
 
     @Inject
     private Gson gson;
-
-    @Inject
-    @VisibleForTesting
-    public MetaNotifier(DinkPlugin plugin) {
-        this.plugin = plugin;
-    }
 
     @Override
     public boolean isEnabled() {
@@ -102,7 +95,6 @@ public class MetaNotifier extends BaseNotifier {
     }
 
     public void onTick() {
-        plugin.addChatSuccess("TICK");
         if (loginTicks.getAndUpdate(i -> Math.max(-1, i - 1)) == 0 && isEnabled()) {
             clientThread.invokeLater(this::notifyLogin); // just 20ms later to be able to run client scripts cleanly
         }
@@ -110,8 +102,6 @@ public class MetaNotifier extends BaseNotifier {
 
     public void onVarbit(VarbitChanged event) {
         if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1 && isEnabled()) {
-            plugin.addChatSuccess("TOA_VAULT_SARCOPHAUS VARBIT CHANGE DETECTED. Value: " + event.getValue() + ", " + (event.getValue() % 2 == 1));
-            System.out.println("TOA_VAULT_SARCOPHAUS VARBIT CHANGE DETECTED. Value: " + event.getValue() + ", " + (event.getValue() % 2 == 1));
             clientThread.invokeAtTickEnd(this::notifyPurpleAmascut);
         }
     }
@@ -169,11 +159,7 @@ public class MetaNotifier extends BaseNotifier {
         }
 
         // Only fire notification if local player region is equal to the TOA reward chamber.
-        plugin.addChatSuccess("REWARD CHAMBER REGION ID IS " + TOA_REWARD_CHAMBER_REGIONID);
-        System.out.print("REWARD CHAMBER REGION ID IS " + TOA_REWARD_CHAMBER_REGIONID);
-        int playerRegion = client.getLocalPlayer().getWorldLocation().getRegionID();
-        plugin.addChatSuccess("LOCAL PLAYER REGION IS " + playerRegion);
-        System.out.print("LOCAL PLAYER REGION IS " + playerRegion);
+        int playerRegion = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
         if ( playerRegion != TOA_REWARD_CHAMBER_REGIONID ) {
             return;
         }

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -2,8 +2,6 @@ package dinkplugin.notifiers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-
-import dinkplugin.DinkPlugin;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -284,8 +284,6 @@ public class MetaNotifier extends BaseNotifier {
             .template("%USERNAME% logged out")
             .replacement("%USERNAME%", Replacements.ofText(playerName))
             .build();
-        cachedPlayerName = null;
-
 
         createMessage(false, NotificationBody.builder()
             .type(NotificationType.LOGOUT)

--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -2,6 +2,8 @@ package dinkplugin.notifiers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+
+import dinkplugin.DinkPlugin;
 import dinkplugin.domain.AchievementDiary;
 import dinkplugin.message.NotificationBody;
 import dinkplugin.message.NotificationType;
@@ -51,9 +53,13 @@ public class MetaNotifier extends BaseNotifier {
     static final @VisibleForTesting String RL_CHAT_CMD_PLUGIN_NAME = ChatCommandsPlugin.class.getSimpleName().toLowerCase();
     static final @VisibleForTesting int INIT_TICKS = 10; // 6 seconds after login
 
+    private static final int TOA_REWARD_CHAMBER_REGIONID = 14672;
+
     private static final int[] TOA_CHEST_VARBS;
 
     private final AtomicInteger loginTicks = new AtomicInteger(-1);
+
+    private final DinkPlugin plugin;
 
     @Inject
     private ClientThread clientThread;
@@ -66,6 +72,12 @@ public class MetaNotifier extends BaseNotifier {
 
     @Inject
     private Gson gson;
+
+    @Inject
+    @VisibleForTesting
+    public MetaNotifier(DinkPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @Override
     public boolean isEnabled() {
@@ -90,6 +102,7 @@ public class MetaNotifier extends BaseNotifier {
     }
 
     public void onTick() {
+        plugin.addChatSuccess("TICK");
         if (loginTicks.getAndUpdate(i -> Math.max(-1, i - 1)) == 0 && isEnabled()) {
             clientThread.invokeLater(this::notifyLogin); // just 20ms later to be able to run client scripts cleanly
         }
@@ -97,6 +110,8 @@ public class MetaNotifier extends BaseNotifier {
 
     public void onVarbit(VarbitChanged event) {
         if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1 && isEnabled()) {
+            plugin.addChatSuccess("TOA_VAULT_SARCOPHAUS VARBIT CHANGE DETECTED. Value: " + event.getValue() + ", " + (event.getValue() % 2 == 1));
+            System.out.println("TOA_VAULT_SARCOPHAUS VARBIT CHANGE DETECTED. Value: " + event.getValue() + ", " + (event.getValue() % 2 == 1));
             clientThread.invokeAtTickEnd(this::notifyPurpleAmascut);
         }
     }
@@ -151,6 +166,16 @@ public class MetaNotifier extends BaseNotifier {
                 // someone else in the party received the purple drop
                 return;
             }
+        }
+
+        // Only fire notification if local player region is equal to the TOA reward chamber.
+        plugin.addChatSuccess("REWARD CHAMBER REGION ID IS " + TOA_REWARD_CHAMBER_REGIONID);
+        System.out.print("REWARD CHAMBER REGION ID IS " + TOA_REWARD_CHAMBER_REGIONID);
+        int playerRegion = client.getLocalPlayer().getWorldLocation().getRegionID();
+        plugin.addChatSuccess("LOCAL PLAYER REGION IS " + playerRegion);
+        System.out.print("LOCAL PLAYER REGION IS " + playerRegion);
+        if ( playerRegion != TOA_REWARD_CHAMBER_REGIONID ) {
+            return;
         }
 
         // Gather relevant data

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -44,6 +44,8 @@ public class WorldUtils {
     private final int TZHAAR_CAVE = 9551;
     public final @VisibleForTesting int TZHAAR_PIT = 9552;
     public final int FORTIS_REGION = 7216;
+    public static final int TOA_REWARD_CHAMBER_REGIONID = 14672;
+
 
     /**
      * @see <a href="https://chisel.weirdgloop.org/varbs/display?varbit=6104#ChangeFrequencyTitle">Chisel</a>

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -44,7 +44,7 @@ public class WorldUtils {
     private final int TZHAAR_CAVE = 9551;
     public final @VisibleForTesting int TZHAAR_PIT = 9552;
     public final int FORTIS_REGION = 7216;
-    public static final int TOA_REWARD_CHAMBER_REGIONID = 14672;
+    public final int TOA_REWARD_CHAMBER_REGION = 14672;
 
 
     /**

--- a/src/main/java/dinkplugin/util/WorldUtils.java
+++ b/src/main/java/dinkplugin/util/WorldUtils.java
@@ -46,7 +46,6 @@ public class WorldUtils {
     public final int FORTIS_REGION = 7216;
     public final int TOA_REWARD_CHAMBER_REGION = 14672;
 
-
     /**
      * @see <a href="https://chisel.weirdgloop.org/varbs/display?varbit=6104#ChangeFrequencyTitle">Chisel</a>
      */


### PR DESCRIPTION
On debugging, `TOA_VAULT_SARCOPHAGUS` is populated as Wardens die and also when you go into the reward chamber. This would mean TOA unique would send before even being able to see in game. So before sending a notifcation for a TOA unique, it will now check the local player region ID to see if it matches the ID of the reward chamber in TOA.

Works on #914.