### PR TITLE
Revert "swap to gradle build method for now"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: Use server loot event for Maggot King drops. (#960)
+- Dev: Switch back to `standard` builds for hub submissions. (#954)
 - Dev: Add gradle `run` task and `logback-test.xml`. (#957)
 
 ## 1.14.2

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Dink for Discord
 author=pajlads
-build=gradle
+build=standard
 description=Discord compatible webhook notifications for Loot, Death, Levels, CLog, KC, Diary, Quests, etc.
 tags=loot,logger,collection,pet,death,xp,level,notifications,discord,speedrun,diary,combat achievements,combat task,barbarian assault,high level gambles
 plugins=dinkplugin.DinkPlugin


### PR DESCRIPTION
Reverts pajlads/DinkPlugin#952 since https://github.com/runelite/plugin-hub-tooling/pull/1 was merged
