### PR TITLE
chore: prevent import or export of proxy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: Use server loot event for Maggot King drops. (#960)
+- Dev: Exclude proxy settings from config export or import. (#955)
 - Dev: Switch back to `standard` builds for hub submissions. (#954)
 - Dev: Add gradle `run` task and `logback-test.xml`. (#957)
 

--- a/src/main/java/dinkplugin/SettingsManager.java
+++ b/src/main/java/dinkplugin/SettingsManager.java
@@ -164,6 +164,8 @@ public class SettingsManager {
             }
         });
         hiddenConfigKeys.add("importPolicy"); // not hidden, but shouldn't be overwritten
+        hiddenConfigKeys.add("proxyServer"); // not hidden, but should only be explicitly set by the user
+        hiddenConfigKeys.add("proxyAuth"); // not hidden, but should only be explicitly set by the user
         webhookConfigKeys = ImmutableSet.<String>builder()
             .add("discordWebhook") // DinkPluginConfig#primaryWebhook
             .addAll(keysBySection.getOrDefault(DinkPluginConfig.webhookSection.toLowerCase().replace(" ", ""), Collections.emptySet()))


### PR DESCRIPTION
Old behavior is probably more harmful than helpful