### PR TITLE
fix(loot): use server event for maggot king drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: Use server loot event for Maggot King drops. (#960)
 - Dev: Add gradle `run` task and `logback-test.xml`. (#957)
 
 ## 1.14.2

--- a/src/main/java/dinkplugin/notifiers/LootNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/LootNotifier.java
@@ -368,7 +368,9 @@ public class LootNotifier extends BaseNotifier {
             NpcID.SAILING_TERN_DEAD,
             NpcID.SAILING_SEA_MOGRE_DEAD,
             NpcID.SAILING_DOLPHIN_DEAD,
-            NpcID.SAILING_VEILED_KRAKEN_DEAD
+            NpcID.SAILING_VEILED_KRAKEN_DEAD,
+            NpcID.MAGGOT_KING,
+            NpcID.MAGGOT_KING_CORPSE
         );
     }
 }


### PR DESCRIPTION
Fixes #959
