### PR TITLE
fix(pet): update olmlet rarity for multiple unique rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Calculate Soup pet luck based on port task completions. (#985)
 - Minor: Add loot notifications for rare deep sea trawling drops. (#971)
 - Minor: Add exchanged items to the trade notification message template. (#962)
+- Bugfix: Calculate olmlet pet rarity accounting for multiple unique rolls and group weighting. (#991)
 - Dev: Add raid metadata for TOA loot notifications. (#978)
 
 ## 1.14.4

--- a/src/main/java/dinkplugin/notifiers/PetNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/PetNotifier.java
@@ -523,11 +523,37 @@ public class PetNotifier extends BaseNotifier {
                 @Override
                 Double getProbability(Client client, KillCountService kcService) {
                     // https://oldschool.runescape.wiki/w/Ancient_chest#Unique_drop_table
-                    int totalPoints = client.getVarbitValue(VarbitID.RAIDS_CLIENT_PARTYSCORE);
+                    int totalPoints = client.getVarbitValue(VarbitID.RAIDS_CLIENT_PARTYSCORE); // assume representative
                     if (totalPoints <= 0) {
                         totalPoints = 26_025;
                     }
-                    return 0.01 * (totalPoints / 8_676) / 53;
+
+                    final double uniqueDropPetRate = 1.0 / 53; // likelihood of a pet drop from a successful unique roll
+                    final int maxPointsPerRoll = 570_000; // "chance is capped at 65.7% (570,000 points) - any further points will be sent to roll for a second unique loot"
+                    final double pointsPerPct = 867_600; // "For every 8,676 total points obtained, a 1% chance to obtain a unique loot is given"
+                    final double rarityForMaxRoll = (maxPointsPerRoll / pointsPerPct) * uniqueDropPetRate; // 1.2% is pet chance for unique roll with max points
+                    int numMaxRolls = Math.min(totalPoints / maxPointsPerRoll, 6); // "Up to six unique rewards can be obtained per raid"
+                    int lastRollPoints = totalPoints % maxPointsPerRoll; // remaining points for a non-max unique roll
+                    double lastRollProb = (lastRollPoints / pointsPerPct) * uniqueDropPetRate; // Prob(unique) * P(pet | unique) = P(pet)
+
+                    // Similar to cumulative geometric: 1 - Prob(all rolls failed to produce a unique) = Prob(at least one unique)
+                    double partyProbability = 1 - Math.pow(1 - rarityForMaxRoll, numMaxRolls) * (1 - lastRollProb);
+
+                    // Party adjustment: pet is more likely to be allocated to players with greater points
+                    double weight;
+                    int partySize = client.getVarbitValue(VarbitID.RAIDS_CLIENT_PARTYSIZE);
+                    if (partySize > 1) {
+                        int personalPoints = client.getVarpValue(VarPlayerID.RAIDS_PLAYERSCORE);
+                        if (personalPoints <= 0) {
+                            personalPoints = totalPoints / partySize;
+                        }
+                        weight = 1.0 * personalPoints / totalPoints;
+                    } else {
+                        weight = 1;
+                    }
+
+                    // Prob(party rolls a pet) * P(local player gets pet | party rolls a pet) = P(local player gets pet)
+                    return partyProbability * weight;
                 }
 
                 @Override


### PR DESCRIPTION
Fix olmlet rarity calculation to account for:

* multiple unique rolls
* party drop allocation
